### PR TITLE
Backported Bsongis/ram saving #6685

### DIFF
--- a/radio/src/audio_arm.cpp
+++ b/radio/src/audio_arm.cpp
@@ -518,7 +518,7 @@ void audioTask(void * pdata)
   RTOS_WAIT_MS(1000); // 1s
 #endif
 
-  if (!unexpectedShutdown) {
+  if (!globalData.unexpectedShutdown) {
     AUDIO_HELLO();
   }
 

--- a/radio/src/gui/128x64/gui.h
+++ b/radio/src/gui/128x64/gui.h
@@ -294,14 +294,12 @@ void drawStatusLine();
 #define drawStatusLine()
 #endif
 
-#define TEXT_FILENAME_MAXLEN         40
-  extern char s_text_file[TEXT_FILENAME_MAXLEN];
   void menuTextView(event_t event);
   void pushMenuTextView(const char *filename);
   void pushModelNotes();
   void readModelNotes();
 
-#define LABEL(...)                     (uint8_t)-1
+#define LABEL(...) (uint8_t)-1
 
 #define CURSOR_MOVED_LEFT(event)       (IS_ROTARY_LEFT(event) || EVT_KEY_MASK(event) == KEY_LEFT)
 #define CURSOR_MOVED_RIGHT(event)      (IS_ROTARY_RIGHT(event) || EVT_KEY_MASK(event) == KEY_RIGHT)

--- a/radio/src/gui/128x64/view_channels.cpp
+++ b/radio/src/gui/128x64/view_channels.cpp
@@ -22,18 +22,19 @@
 
 void menuChannelsView(event_t event)
 {
-  static bool longNames = false;
   bool newLongNames = false;
-  static bool secondPage = false;
-  static bool mixersView = false;
 
   uint8_t ch;
 
-  switch(event)
-  {
+  switch (event) {
+    case EVT_ENTRY:
+      memclear(&reusableBuffer.viewChannels, sizeof(reusableBuffer.viewChannels));
+      break;
+
     case EVT_KEY_BREAK(KEY_EXIT):
       popMenu();
       break;
+
 #if defined(PCBI6)
     case EVT_KEY_FIRST(KEY_UP):
     case EVT_KEY_FIRST(KEY_DOWN):
@@ -41,19 +42,20 @@ void menuChannelsView(event_t event)
     case EVT_KEY_FIRST(KEY_RIGHT):
     case EVT_KEY_FIRST(KEY_LEFT):
 #endif
-      secondPage = !secondPage;
+      reusableBuffer.viewChannels.secondPage = !reusableBuffer.viewChannels.secondPage;
       break;
+
     case EVT_KEY_FIRST(KEY_ENTER):
-      mixersView = !mixersView;
+      reusableBuffer.viewChannels.mixersView = !reusableBuffer.viewChannels.mixersView;
       break;
   }
 
-  if (secondPage)
+  if (reusableBuffer.viewChannels.secondPage)
     ch = 16;
   else
     ch = 0;
 
-  if (mixersView) {
+  if (reusableBuffer.viewChannels.mixersView) {
     lcdDrawTextAlignedCenter(0, MIXERS_MONITOR);
   }
   else {
@@ -72,13 +74,13 @@ void menuChannelsView(event_t event)
     // Channels
     for (uint8_t line=0; line<8; line++) {
       uint8_t y = 9+line*7;
-      int32_t val = (mixersView) ? ex_chans[ch] : channelOutputs[ch];
+      int32_t val = (reusableBuffer.viewChannels.mixersView) ? ex_chans[ch] : channelOutputs[ch];
       uint8_t ofs = (col ? 0 : 1);
 
       // Channel name if present, number if not
       uint8_t lenLabel = ZLEN(g_model.limitData[ch].name);
       if (lenLabel > 4) {
-        newLongNames = longNames = true;
+        newLongNames = reusableBuffer.viewChannels.longNames = true;
       }
 
       if (lenLabel > 0)
@@ -88,10 +90,10 @@ void menuChannelsView(event_t event)
 
       // Value
 #if defined(PPM_UNIT_US)
-      uint8_t wbar = (longNames ? 54 : 64);
+      uint8_t wbar = (reusableBuffer.viewChannels.longNames ? 54 : 64);
       lcdDrawNumber(x+LCD_W/2-3-wbar-ofs, y+1, PPM_CH_CENTER(ch)+val/2, TINSIZE|RIGHT);
 #elif defined(PPM_UNIT_PERCENT_PREC1)
-      uint8_t wbar = (longNames ? 48 : 58);
+      uint8_t wbar = (reusableBuffer.viewChannels.longNames ? 48 : 58);
       lcdDrawNumber(x+LCD_W/2-3-wbar-ofs, y+1, calcRESXto1000(val), PREC1|TINSIZE|RIGHT);
 #else
       uint8_t wbar = (longNames ? 54 : 64);
@@ -110,5 +112,5 @@ void menuChannelsView(event_t event)
     }
   }
 
-  longNames = newLongNames;
+  reusableBuffer.viewChannels.longNames = newLongNames;
 }

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -564,7 +564,7 @@ void menuMainView(event_t event)
 #if defined(LOG_TELEMETRY) || defined(WATCHDOG_DISABLED)
   lcdDrawChar(REBOOT_X, 0*FH, '!', INVERS);
 #else
-  if (unexpectedShutdown) {
+  if (globalData.unexpectedShutdown) {
     lcdDrawChar(REBOOT_X, 0*FH, '!', INVERS);
   }
 #endif

--- a/radio/src/gui/128x64/view_statistics.cpp
+++ b/radio/src/gui/128x64/view_statistics.cpp
@@ -160,7 +160,7 @@ void menuStatisticsDebug(event_t event)
   if ((ResetReason&RSTC_SR_RSTTYP) == (2<<8)) {
     lcdDrawText(LCD_W-8*FW, 0*FH, "WATCHDOG");
   }
-  else if (unexpectedShutdown) {
+  else if (globalData.unexpectedShutdown) {
     lcdDrawText(LCD_W-13*FW, 0*FH, "UNEXP.SHTDOWN");
   }
 #endif

--- a/radio/src/gui/212x64/gui.h
+++ b/radio/src/gui/212x64/gui.h
@@ -290,16 +290,12 @@ extern char statusLineMsg[STATUS_LINE_LENGTH];
 void showStatusLine();
 void drawStatusLine();
 
-#define TEXT_FILENAME_MAXLEN           40
-extern char s_text_file[TEXT_FILENAME_MAXLEN];
 void menuTextView(event_t event);
 void pushMenuTextView(const char *filename);
 void pushModelNotes();
 void readModelNotes();
 
 void menuChannelsView(event_t event);
-
-#define LABEL(...) (uint8_t)-1
 
 #if defined(ROTARY_ENCODER_NAVIGATION)
 #define CURSOR_MOVED_LEFT(event)       (event==EVT_ROTARY_LEFT)

--- a/radio/src/gui/212x64/view_channels.cpp
+++ b/radio/src/gui/212x64/view_channels.cpp
@@ -22,44 +22,46 @@
 
 void menuChannelsView(event_t event)
 {
-  static bool longNames = false;
-  static bool secondPage = false;
-  static bool mixersView = false;
   uint8_t ch = 0;
-  uint8_t wbar = (longNames ? 54 : 64);
+  uint8_t wbar = (reusableBuffer.viewChannels.longNames ? 54 : 64);
   int16_t limits = 512 * 2;
 
 #if defined(PPM_UNIT_PERCENT_PREC1)
   wbar -= 6;
 #endif
 
-  switch(event)
-  {
+  switch(event) {
+    case EVT_ENTRY:
+      memclear(&reusableBuffer.viewChannels, sizeof(reusableBuffer.viewChannels));
+      break;
+
     case EVT_KEY_BREAK(KEY_EXIT):
       popMenu();
       break;
+
     case EVT_KEY_FIRST(KEY_RIGHT):
     case EVT_KEY_FIRST(KEY_LEFT):
 #if defined(ROTARY_ENCODER_NAVIGATION)
     case EVT_ROTARY_LEFT:
     case EVT_ROTARY_RIGHT:
 #endif
-      secondPage = !secondPage;
+      reusableBuffer.viewChannels.secondPage = !reusableBuffer.viewChannels.secondPage;
       break;
+
     case EVT_KEY_FIRST(KEY_ENTER):
-      mixersView = !mixersView;
+      reusableBuffer.viewChannels.mixersView = !reusableBuffer.viewChannels.mixersView;
       break;
   }
 
-  if (secondPage)
+  if (reusableBuffer.viewChannels.secondPage)
     ch = 16;
 
-  if (mixersView)
+  if (reusableBuffer.viewChannels.mixersView)
     limits *= 2;  // this could be handled nicer, but slower, by checking actual range for this mixer
   else if (g_model.extendedLimits)
     limits *= LIMIT_EXT_PERCENT / 100;
 
-  if (mixersView)
+  if (reusableBuffer.viewChannels.mixersView)
     lcdDrawTextAlignedCenter(0, MIXERS_MONITOR);
   else
     lcdDrawTextAlignedCenter(0, CHANNELS_MONITOR);
@@ -76,13 +78,13 @@ void menuChannelsView(event_t event)
     // Channels
     for (uint8_t line=0; line < 8; line++) {
       const uint8_t y = 9 + line * 7;
-      const int32_t val = mixersView ? ex_chans[ch] : channelOutputs[ch];
+      const int32_t val = reusableBuffer.viewChannels.mixersView ? ex_chans[ch] : channelOutputs[ch];
       const uint8_t lenLabel = ZLEN(g_model.limitData[ch].name);
 
       // Channel name if present, number if not
       if (lenLabel > 0) {
         if (lenLabel > 4)
-          longNames = true;
+          reusableBuffer.viewChannels.longNames = true;
         lcdDrawSizedText(x+1-ofs, y, g_model.limitData[ch].name, sizeof(g_model.limitData[ch].name), ZCHAR | SMLSIZE);
       }
       else {

--- a/radio/src/gui/480x272/menus.cpp
+++ b/radio/src/gui/480x272/menus.cpp
@@ -70,11 +70,11 @@ void readModelNotes()
 {
   LED_ERROR_BEGIN();
 
-  strcpy(s_text_file, MODELS_PATH "/");
-  char *buf = strcat_currentmodelname(&s_text_file[sizeof(MODELS_PATH)]);
+  strcpy(reusableBuffer.viewText.filename, MODELS_PATH "/");
+  char *buf = strcat_currentmodelname(&reusableBuffer.viewText.filename[sizeof(MODELS_PATH)]);
   strcpy(buf, TEXT_EXT);
-  if (!isFileAvailable(s_text_file)) {
-    char *buf = strAppendFilename(&s_text_file[sizeof(MODELS_PATH)], g_eeGeneral.currModelFilename, LEN_MODEL_FILENAME);
+  if (!isFileAvailable(reusableBuffer.viewText.filename)) {
+    char *buf = strAppendFilename(&reusableBuffer.viewText.filename[sizeof(MODELS_PATH)], g_eeGeneral.currModelFilename, LEN_MODEL_FILENAME);
     strcpy(buf, TEXT_EXT);
   }
 
@@ -95,11 +95,11 @@ void readModelNotes()
 bool menuModelNotes(event_t event)
 {
   if (event == EVT_ENTRY) {
-    strcpy(s_text_file, MODELS_PATH "/");
-    char *buf = strcat_currentmodelname(&s_text_file[sizeof(MODELS_PATH)]);
+    strcpy(reusableBuffer.viewText.filename, MODELS_PATH "/");
+    char *buf = strcat_currentmodelname(&reusableBuffer.viewText.filename[sizeof(MODELS_PATH)]);
     strcpy(buf, TEXT_EXT);
-    if (!isFileAvailable(s_text_file)) {
-      char *buf = strAppendFilename(&s_text_file[sizeof(MODELS_PATH)], g_eeGeneral.currModelFilename, LEN_MODEL_FILENAME);
+    if (!isFileAvailable(reusableBuffer.viewText.filename)) {
+      char * buf = strAppendFilename(&reusableBuffer.viewText.filename[sizeof(MODELS_PATH)], g_eeGeneral.currModelFilename, LEN_MODEL_FILENAME);
       strcpy(buf, TEXT_EXT);
     }
   }

--- a/radio/src/gui/480x272/view_text.cpp
+++ b/radio/src/gui/480x272/view_text.cpp
@@ -20,80 +20,6 @@
 
 #include "opentx.h"
 
-#define TEXT_FILE_MAXSIZE     2048
-
-char s_text_file[TEXT_FILENAME_MAXLEN];
-char s_text_screen[NUM_BODY_LINES][LCD_COLS+1];
-
-void readTextFile(int & lines_count)
-{
-  FIL file;
-  int result;
-  char c;
-  unsigned int sz;
-  int line_length = 0;
-  int escape = 0;
-  char escape_chars[2];
-  int current_line = 0;
-
-  memset(s_text_screen, 0, sizeof(s_text_screen));
-
-  result = f_open(&file, s_text_file, FA_OPEN_EXISTING | FA_READ);
-  if (result == FR_OK) {
-    for (int i=0; i<TEXT_FILE_MAXSIZE && f_read(&file, &c, 1, &sz)==FR_OK && sz==1 && (lines_count==0 || current_line-menuVerticalOffset<NUM_BODY_LINES); i++) {
-      if (c == '\n') {
-        ++current_line;
-        line_length = 0;
-        escape = 0;
-      }
-      else if (c!='\r' && current_line>=menuVerticalOffset && current_line-menuVerticalOffset<NUM_BODY_LINES && line_length<LCD_COLS) {
-        if (c=='\\' && escape==0) {
-          escape = 1;
-          continue;
-        }
-        else if (c!='\\' && escape>0 && escape<4) {
-          escape_chars[escape-1] = c;
-          if (escape == 2 && !strncmp(escape_chars, "up", 2)) {
-            c = '\300';
-            escape = 0;
-          }
-          else if (escape == 2 && !strncmp(escape_chars, "dn", 2)) {
-            c = '\301';
-            escape = 0;
-          }
-          else if (escape == 3) {
-            int val = atoi(escape_chars);
-            if (val >= 200 && val < 225) {
-              c = '\200' + val-200;
-            }
-            escape = 0;
-          }
-          else {
-            escape++;
-            continue;
-          }
-        }
-        else if (c=='~') {
-          c = 'z'+1;
-        }
-        else if (c=='\t') {
-          c = 0x1D; //tab
-        }
-        escape = 0;
-        s_text_screen[current_line-menuVerticalOffset][line_length++] = c;
-      }
-    }
-    if (c != '\n') {
-      current_line += 1;
-    }
-    f_close(&file);
-  }
-
-  if (lines_count == 0) {
-    lines_count = current_line;
-  }
-}
-
 bool menuTextView(event_t event)
 {
   static int lines_count;
@@ -104,7 +30,7 @@ bool menuTextView(event_t event)
     case EVT_ENTRY:
       menuVerticalOffset = 0;
       lines_count = 0;
-      readTextFile(lines_count);
+      sdReadTextFile(reusableBuffer.viewText.filename, reusableBuffer.viewText.lines, lines_count);
       break;
 
     case EVT_ROTARY_LEFT:
@@ -112,7 +38,7 @@ bool menuTextView(event_t event)
         break;
       else
         menuVerticalOffset--;
-      readTextFile(lines_count);
+      sdReadTextFile(reusableBuffer.viewText.filename, reusableBuffer.viewText.lines, lines_count);
       break;
 
     case EVT_ROTARY_RIGHT:
@@ -120,7 +46,7 @@ bool menuTextView(event_t event)
         break;
       else
         ++menuVerticalOffset;
-      readTextFile(lines_count);
+      sdReadTextFile(reusableBuffer.viewText.filename, reusableBuffer.viewText.lines, lines_count);
       break;
 
     case EVT_KEY_FIRST(KEY_EXIT):
@@ -129,7 +55,7 @@ bool menuTextView(event_t event)
   }
 
   for (int i=0; i<NUM_BODY_LINES; i++) {
-    lcdDrawText(MENUS_MARGIN_LEFT, MENU_CONTENT_TOP + i*FH, s_text_screen[i]);
+    lcdDrawText(MENUS_MARGIN_LEFT, MENU_CONTENT_TOP + i*FH, reusableBuffer.viewText.lines[i]);
   }
 
 #if 0
@@ -148,7 +74,7 @@ bool menuTextView(event_t event)
 void pushMenuTextView(const char *filename)
 {
   if (strlen(filename) < TEXT_FILENAME_MAXLEN) {
-    strcpy(s_text_file, filename);
+    strcpy(reusableBuffer.viewText.filename, filename);
     pushMenu(menuTextView);
   }
 }

--- a/radio/src/keys.cpp
+++ b/radio/src/keys.cpp
@@ -38,7 +38,7 @@
 #define KSTATE_KILLED 99
 
 event_t s_evt;
-struct t_inactivity inactivity = {0};
+struct InactivityData inactivity = {0};
 Key keys[NUM_KEYS];
 
 event_t getEvent(bool trim) {

--- a/radio/src/main_arm.cpp
+++ b/radio/src/main_arm.cpp
@@ -432,24 +432,23 @@ void perMain()
   event_t evt = getEvent(false);
 
 #if defined(RAMBACKUP)
-  if (unexpectedShutdown) {
+  if (globalData.unexpectedShutdown) {
     drawFatalErrorScreen(STR_EMERGENCY_MODE);
     return;
   }
 #endif
 
 #if defined(STM32)
-  static bool sdcard_present_before = SD_CARD_PRESENT();
-  bool sdcard_present_now = SD_CARD_PRESENT();
-  if (sdcard_present_now && !sdcard_present_before) {
+  bool sdcardPresent = SD_CARD_PRESENT();
+  if (sdcardPresent && !globalData.sdcardPresent) {
     sdMount();
   }
-  sdcard_present_before = sdcard_present_now;
+  globalData.sdcardPresent = sdcardPresent;
 #endif
 
 #if !defined(EEPROM)
   // In case the SD card is removed during the session
-  if (!SD_CARD_PRESENT() && !unexpectedShutdown) {
+  if (!SD_CARD_PRESENT() && !globalData.unexpectedShutdown) {
     drawFatalErrorScreen(STR_NO_SDCARD);
     return;
   }

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -29,10 +29,9 @@ Clipboard clipboard;
 
 uint8_t unexpectedShutdown = 0;
 
-/* AVR: mixer duration in 1/16ms */
-/* ARM: mixer duration in 0.5us */
-uint16_t maxMixerDuration;
+GlobalData globalData;
 
+uint16_t maxMixerDuration; // step = 0.01ms
 uint8_t heartbeat;
 
 #if defined(OVERRIDE_CHANNEL_FUNCTION)
@@ -1768,7 +1767,7 @@ void opentxInit(OPENTX_INIT_ARGS) {
   //  * radios without CPU controlled power can only use Reset status register (if available)
   if (UNEXPECTED_SHUTDOWN()) {
     TRACE("Unexpected Shutdown detected");
-    unexpectedShutdown = 1;
+    globalData.unexpectedShutdown = 1;
   }
 
 #if defined(SDCARD) && !defined(PCBMEGA2560)
@@ -1785,7 +1784,7 @@ void opentxInit(OPENTX_INIT_ARGS) {
 #endif
 
 #if defined(PCBHORUS)
-  if (!unexpectedShutdown) {
+  if (!globalData.unexpectedShutdown) {
     // g_model.topbarData is still zero here (because it was not yet read from SDCARD),
     // but we only remember the pointer to in in constructor.
     // The storageReadAll() needs topbar object, so it must be created here
@@ -1809,7 +1808,7 @@ void opentxInit(OPENTX_INIT_ARGS) {
   // handling of storage for radios that have no EEPROM
 #if !defined(EEPROM)
 #if defined(RAMBACKUP)
-  if (unexpectedShutdown) {
+  if (globalData.unexpectedShutdown) {
     // SDCARD not available, try to restore last model from RAM
     TRACE("rambackupRestore");
     rambackupRestore();
@@ -1866,7 +1865,7 @@ void opentxInit(OPENTX_INIT_ARGS) {
     backlightOn();
   }
 
-  if (!unexpectedShutdown) {
+  if (!globalData.unexpectedShutdown) {
     opentxStart();
   }
   TRACE("start done");

--- a/radio/src/sdcard.cpp
+++ b/radio/src/sdcard.cpp
@@ -402,6 +402,74 @@ bool sdListFiles(const char * path, const char * extension, const uint8_t maxlen
   return popupMenuNoItems;
 }
 
+constexpr uint32_t TEXT_FILE_MAXSIZE = 2048;
+
+void sdReadTextFile(const char * filename, char lines[NUM_BODY_LINES][LCD_COLS + 1], int & lines_count)
+{
+  FIL file;
+  int result;
+  char c;
+  unsigned int sz;
+  int line_length = 0;
+  uint8_t escape = 0;
+  char escape_chars[4] = {0};
+  int current_line = 0;
+
+  memclear(lines, NUM_BODY_LINES * (LCD_COLS + 1));
+
+  result = f_open(&file, filename, FA_OPEN_EXISTING | FA_READ);
+  if (result == FR_OK) {
+    for (unsigned i = 0; i < TEXT_FILE_MAXSIZE && f_read(&file, &c, 1, &sz) == FR_OK && sz == 1 && (lines_count == 0 || current_line - menuVerticalOffset < NUM_BODY_LINES); i++) {
+      if (c == '\n') {
+        ++current_line;
+        line_length = 0;
+        escape = 0;
+      }
+      else if (c!='\r' && current_line>=menuVerticalOffset && current_line-menuVerticalOffset<NUM_BODY_LINES && line_length<LCD_COLS) {
+        if (c == '\\' && escape == 0) {
+          escape = 1;
+          continue;
+        }
+        else if (c != '\\' && escape > 0 && escape < sizeof(escape_chars)) {
+          escape_chars[escape - 1] = c;
+          if (escape == 2 && !strncmp(escape_chars, "up", 2)) {
+            c = '\300';
+          }
+          else if (escape == 2 && !strncmp(escape_chars, "dn", 2)) {
+            c = '\301';
+          }
+          else if (escape == 3) {
+            int val = atoi(escape_chars);
+            if (val >= 200 && val < 225) {
+              c = '\200' + val-200;
+            }
+          }
+          else {
+            escape++;
+            continue;
+          }
+        }
+        else if (c=='~') {
+          c = 'z'+1;
+        }
+        else if (c=='\t') {
+          c = 0x1D; //tab
+        }
+        escape = 0;
+        lines[current_line-menuVerticalOffset][line_length++] = c;
+      }
+    }
+    if (c != '\n') {
+      current_line += 1;
+    }
+    f_close(&file);
+  }
+
+  if (lines_count == 0) {
+    lines_count = current_line;
+  }
+}
+
 // returns true if current working dir is at the root level
 bool isCwdAtRoot()
 {

--- a/radio/src/sdcard.h
+++ b/radio/src/sdcard.h
@@ -154,6 +154,8 @@ const char * sdCopyFile(const char * srcFilename, const char * srcDir, const cha
 #define LIST_SD_FILE_EXT    2
 bool sdListFiles(const char * path, const char * extension, const uint8_t maxlen, const char * selection, uint8_t flags=0);
 
+void sdReadTextFile(const char * filename, char lines[NUM_BODY_LINES][LCD_COLS + 1], int & lines_count);
+
 bool isCwdAtRoot();
 FRESULT sdReadDir(DIR * dir, FILINFO * fno, bool & firstTime);
 

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -41,17 +41,17 @@ enum LogicalSwitchContextState {
   SWITCH_ENABLE
 };
 
-PACK(typedef struct {
+PACK(struct LogicalSwitchContext {
   uint8_t state:1;
   uint8_t timerState:2;
   uint8_t spare:5;
   uint8_t timer;
   int16_t lastValue;
-}) LogicalSwitchContext;
+});
 
-PACK(typedef struct {
+PACK(struct LogicalSwitchesFlightModeContext {
   LogicalSwitchContext lsw[MAX_LOGICAL_SWITCHES];
-}) LogicalSwitchesFlightModeContext;
+});
 LogicalSwitchesFlightModeContext lswFm[MAX_FLIGHT_MODES];
 
 #define LS_LAST_VALUE(fm, idx) lswFm[fm].lsw[idx].lastValue

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -485,8 +485,8 @@ void backlightEnable(uint8_t dutyCycle);
 #else
 #define BACKLIGHT_LEVEL_MIN   46
 #endif
-#define BACKLIGHT_ENABLE()    backlightEnable(unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : BACKLIGHT_LEVEL_MAX-g_eeGeneral.backlightBright)
-#define BACKLIGHT_DISABLE()   backlightEnable(unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : ((g_eeGeneral.blOffBright == BACKLIGHT_LEVEL_MIN) && (g_eeGeneral.backlightMode != e_backlight_mode_off)) ? 0 : g_eeGeneral.blOffBright)
+#define BACKLIGHT_ENABLE()    backlightEnable(globalData.unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : BACKLIGHT_LEVEL_MAX-g_eeGeneral.backlightBright)
+#define BACKLIGHT_DISABLE()   backlightEnable(globalData.unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : ((g_eeGeneral.blOffBright == BACKLIGHT_LEVEL_MIN) && (g_eeGeneral.backlightMode != e_backlight_mode_off)) ? 0 : g_eeGeneral.blOffBright)
 #define isBacklightEnabled()  true
 
 #if !defined(SIMU)

--- a/radio/src/targets/sky9x/lcd_driver.cpp
+++ b/radio/src/targets/sky9x/lcd_driver.cpp
@@ -163,7 +163,7 @@ void lcdInit()
 
 #if defined(REVX)
   // 200mS delay (only if not wdt reset)
-  if ( ( ( ResetReason & RSTC_SR_RSTTYP ) != (2 << 8) ) && !unexpectedShutdown ) {
+  if ( ( ( ResetReason & RSTC_SR_RSTTYP ) != (2 << 8) ) && !globalData.unexpectedShutdown ) {
     for (uint32_t j = 0; j < 100; j += 1 ) {
       TC0->TC_CHANNEL[0].TC_CCR = 5; // Enable clock and trigger it (may only need trigger)
       while ( TC0->TC_CHANNEL[0].TC_CV < 36000 ) {

--- a/radio/src/tasks_arm.h
+++ b/radio/src/tasks_arm.h
@@ -18,8 +18,8 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _TASKS_ARM_H_
-#define _TASKS_ARM_H_
+#ifndef _TASKS_H_
+#define _TASKS_H_
 
 #include "rtos.h"
 
@@ -30,8 +30,8 @@
 #else
 #define MENUS_STACK_SIZE       2048
 #endif
-#define MIXER_STACK_SIZE       512
-#define AUDIO_STACK_SIZE       512
+#define MIXER_STACK_SIZE       400
+#define AUDIO_STACK_SIZE       400
 #define CLI_STACK_SIZE         1024  // only consumed with CLI build option
 #define MIXER_TASK_PRIO        5
 #define AUDIO_TASK_PRIO        7
@@ -59,4 +59,4 @@ inline void resetForcePowerOffRequest()
   timeForcePowerOffPressed = 0;
 }
 
-#endif // _TASKS_ARM_H_
+#endif // _TASKS_H_

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -25,10 +25,6 @@ uint8_t telemetryStreaming = 0;
 uint8_t telemetryRxBuffer[TELEMETRY_RX_PACKET_SIZE];   // Receive buffer. 9 bytes (full packet), worst case 18 bytes with byte-stuffing (+1)
 uint8_t telemetryRxBufferCount = 0;
 
-#if defined(WS_HOW_HIGH)
-uint8_t wshhStreaming = 0;
-#endif
-
 uint8_t telemetryState = TELEMETRY_INIT;
 
 TelemetryData telemetryData;
@@ -181,7 +177,6 @@ void telemetryWakeup()
 
 void telemetryInterrupt10ms()
 {
-
   if (TELEMETRY_STREAMING()) {
     if (!TELEMETRY_OPENXSENSOR()) {
       for (int i=0; i<MAX_TELEMETRY_SENSORS; i++) {

--- a/tools/extract-map.py
+++ b/tools/extract-map.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python3
+
+import argparse
+
+
+def line_index(lines, start):
+    for i, line in enumerate(lines):
+        if line.startswith(start):
+            return i
+
+
+def extract_vars(lines):
+    result = []
+    lines = lines[line_index(lines, ".data"):line_index(lines, ".memory")]
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        if line.startswith("*"):
+            continue
+        if line.startswith(" .data.") or line.startswith(" .bss."):
+            fields = (line + lines[i]).split()
+            # print(fields)
+            i += 1
+            var = fields[0].split(".")[-1]
+            offset = int(fields[1], 16)
+            size = int(fields[2], 16)
+            result.append((var, offset, size))
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract firmware.map")
+    parser.add_argument("file", type=argparse.FileType("r"))
+
+    args = parser.parse_args()
+
+    f = args.file
+    lines = f.readlines()
+
+    vars = extract_vars(lines)
+    vars.sort(key=lambda var: "%08d %s" % (var[2], var[0]))
+    for var, offset, size in vars:
+        print("%s\t %d" % (var, size))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Backported Bsongis/ram saving #6685
In our case this reclaims 576 bytes of RAM, leaving total of 1112 bytes free at the moment.
The most of it is change to MIXER_STACK_SIZE - it's now exactly as in current OpenTX.
My basic tests showed no issue so far.

https://github.com/opentx/opentx/pull/6685/files