### PR TITLE
Bootloader

### DIFF
--- a/radio/src/targets/flysky/backlight_driver.cpp
+++ b/radio/src/targets/flysky/backlight_driver.cpp
@@ -24,11 +24,10 @@
 
 void backlightInit()
 {
-    RCC_AHBPeriphClockCmd(BACKLIGHT_RCC_AHB1Periph, ENABLE);
     GPIO_InitTypeDef gpio_init;
     gpio_init.GPIO_Mode  = GPIO_Mode_OUT;
     gpio_init.GPIO_OType = GPIO_OType_PP;
-    gpio_init.GPIO_Speed = GPIO_Speed_50MHz;
+    gpio_init.GPIO_Speed = GPIO_Speed_2MHz;
     gpio_init.GPIO_PuPd  = GPIO_PuPd_NOPULL;
     gpio_init.GPIO_Pin   = BACKLIGHT_GPIO_PIN;
     GPIO_Init(BACKLIGHT_GPIO, &gpio_init);

--- a/radio/src/targets/flysky/board.h
+++ b/radio/src/targets/flysky/board.h
@@ -74,7 +74,7 @@ extern "C" {
 #endif
 
 #define FLASHSIZE                       0x20000  // 128 kb
-#define BOOTLOADER_SIZE                 0x0
+#define BOOTLOADER_SIZE                 0x4000   //  16 kb
 #define FIRMWARE_ADDRESS                0x08000000
 
 #define LUA_MEM_MAX                     (0)    // max allowed memory usage for complete Lua  (in bytes), 0 means unlimited
@@ -471,7 +471,7 @@ void hapticOff(void);
 
 // Second serial port driver
 #if defined(SERIAL_GPIO)
-#define DEBUG_BAUDRATE                  921600
+#define DEBUG_BAUDRATE                  115200
 #define SERIAL2
 extern uint8_t serial2Mode;
 void serial2Init(unsigned int mode, unsigned int protocol);

--- a/radio/src/targets/flysky/bootloader/boot_menu.cpp
+++ b/radio/src/targets/flysky/bootloader/boot_menu.cpp
@@ -1,93 +1,80 @@
-#include "opentx.h"
 #include "../../common/arm/stm32/bootloader/boot.h"
+#include "opentx.h"
 #if defined(SDCARD)
-  #include "../../common/arm/stm32/bootloader/bin_files.h"
+#include "../../common/arm/stm32/bootloader/bin_files.h"
 
-  extern MemoryType memoryType;
+extern MemoryType memoryType;
 #endif
-void bootloaderInitScreen()
-{
+void bootloaderInitScreen() {
+  backlightEnable(1);
 }
 
-static void bootloaderDrawMsg(unsigned int x, const char *str, uint8_t line, bool inverted)
-{
+static void bootloaderDrawMsg(unsigned int x, const char* str, uint8_t line, bool inverted) {
   lcdDrawSizedText(x, (line + 2) * FH, str, DISPLAY_CHAR_WIDTH, inverted ? INVERS : 0);
 }
 
-void bootloaderDrawFilename(const char *str, uint8_t line, bool selected)
-{
+void bootloaderDrawFilename(const char* str, uint8_t line, bool selected) {
   bootloaderDrawMsg(INDENT_WIDTH, str, line, selected);
 }
 
-void bootloaderDrawScreen(BootloaderState st, int opt, const char *str)
-{
+void bootloaderDrawScreen(BootloaderState st, int opt, const char* str) {
   lcdClear();
-  lcdDrawText(LCD_W / 2, 0, BOOTLOADER_TITLE, CENTERED);
-  lcdInvertLine(0);
+  lcdDrawText(0, 0, BOOTLOADER_TITLE, INVERS);
 
   if (st == ST_START) {
-    #if defined(SDCARD)
-      lcdDrawText(3*FW, 2*FH, "Write Firmware", opt == 0 ? INVERS : 0);
-      lcdDrawText(3*FW, 3*FH, "Restore EEPROM", opt == 1 ? INVERS : 0);
-    #endif
-    lcdDrawText(3*FW, 4*FH, "Exit", opt == 2 ? INVERS : 0);
-
-    lcdDrawText(LCD_W / 2, 5 * FH + FH / 2, STR_OR_PLUGIN_USB_CABLE, CENTERED);
-
-    // Remove "opentx-" from string
-    const char * vers = getOtherVersion(nullptr);
-#if LCD_W < 212
-    if (strncmp(vers, "opentx-", 7) == 0)
-      vers += 7;
+#if defined(SDCARD)
+    lcdDrawTextAlignedLeft(2 * FH, "\010Write Firmware");
+    lcdDrawTextAlignedLeft(3 * FH, "\010Restore EEPROM");
 #endif
-    lcdDrawText(LCD_W / 2, 7 * FH, vers, CENTERED);
-    lcdInvertLine(7);
-  }
-  else if (st == ST_USB) {
+    lcdDrawTextAlignedLeft(4 * FH, "Exit");
+
+    lcdDrawTextAlignedLeft(6 * FH, "\001FW:");
+
+    // Remove opentx- from string
+    const char* other_ver = getOtherVersion(nullptr);
+    if (strstr(other_ver, "opentx-"))
+      other_ver = other_ver + 7;
+    lcdDrawText(20, 6 * FH, other_ver);
+
+    lcdInvertLine(2 + 2 + opt); // only Exit on I6X
+    lcdDrawTextAlignedLeft(7 * FH, STR_OR_PLUGIN_USB_CABLE);
+  } else if (st == ST_USB) {
     lcdDrawTextAlignedLeft(4 * FH, STR_USB_CONNECTED);
-  }
-  else if (st == ST_DIR_CHECK) {
-    #if defined(SDCARD)
+  } else if (st == ST_DIR_CHECK) {
+#if defined(SDCARD)
     if (opt == FR_NO_PATH) {
       bootloaderDrawMsg(INDENT_WIDTH, "Directory is missing!", 1, false);
       bootloaderDrawMsg(INDENT_WIDTH, getBinaryPath(memoryType), 2, false);
-    }
-    else {
+    } else {
       bootloaderDrawMsg(INDENT_WIDTH, "Directory is empty!", 1, false);
     }
-    #endif
-  }
-  else if (st == ST_FLASH_CHECK) {
-     #if defined(SDCARD)
+#endif
+  } else if (st == ST_FLASH_CHECK) {
+#if defined(SDCARD)
     if (opt == FC_ERROR) {
       if (memoryType == MEM_FLASH)
         bootloaderDrawMsg(0, STR_INVALID_FIRMWARE, 2, false);
       else
         bootloaderDrawMsg(0, STR_INVALID_EEPROM, 2, false);
-    }
-    else if (opt == FC_OK) {
-      if (memoryType == MEM_FLASH) {
-        const char * vers = getOtherVersion((char*)Block_buffer);
+    } else if (opt == FC_OK) {
+      const char* vers = getOtherVersion((char*)Block_buffer);
 #if LCD_W < 212
-        // Remove "opentx-" from string
-        if (strncmp(vers, "opentx-", 7) == 0)
-          vers += 7;
+      // Remove opentx- from string
+      if (strstr(vers, "opentx-"))
+        vers = vers + 7;
 #endif
-        bootloaderDrawMsg(INDENT_WIDTH, vers, 0, false);
-      }
-      bootloaderDrawMsg(0, STR_HOLD_ENTER_TO_START, 2, false);
+      bootloaderDrawMsg(INDENT_WIDTH, vers, 0, false);
     }
-    #endif
-  }
-  else if (st == ST_FLASHING) {
+    bootloaderDrawMsg(0, STR_HOLD_ENTER_TO_START, 2, false);
+#endif
+  } else if (st == ST_FLASHING) {
     lcdDrawTextAlignedLeft(4 * FH, CENTER "\015Writing...");
 
     lcdDrawRect(3, 6 * FH + 4, (LCD_W - 8), 7);
     lcdDrawSolidHorizontalLine(5, 6 * FH + 6, (LCD_W - 12) * opt / 100, FORCE);
     lcdDrawSolidHorizontalLine(5, 6 * FH + 7, (LCD_W - 12) * opt / 100, FORCE);
     lcdDrawSolidHorizontalLine(5, 6 * FH + 8, (LCD_W - 12) * opt / 100, FORCE);
-  }
-  else if (st == ST_FLASH_DONE) {
+  } else if (st == ST_FLASH_DONE) {
     lcdDrawTextAlignedLeft(4 * FH, CENTER "\007Writing complete");
   }
 }

--- a/radio/src/targets/flysky/hal.h
+++ b/radio/src/targets/flysky/hal.h
@@ -574,7 +574,7 @@ F072 IRQs
 #define MIXER_SCHEDULER_TIMER_IRQHandler     TIM17_IRQHandler
 
 //all used RCC goes here
-#define RCC_AHB1_LIST                   (LCD_RCC_AHB1Periph | KEYS_RCC_AHB1Periph | RCC_AHBPeriph_GPIOB | BUZZER_RCC_AHBPeriph | EXTMODULE_RCC_AHBPeriph)
+#define RCC_AHB1_LIST                   (BACKLIGHT_RCC_AHB1Periph | LCD_RCC_AHB1Periph | KEYS_RCC_AHB1Periph | RCC_AHBPeriph_GPIOB | BUZZER_RCC_AHBPeriph | EXTMODULE_RCC_AHBPeriph)
 #define RCC_APB1_LIST                   (INTERRUPT_xMS_RCC_APB1Periph | TIMER_2MHz_RCC_APB1Periph | I2C_RCC_APB1Periph)
 #define RCC_APB2_LIST                   (MIXER_SCHEDULER_TIMER_RCC_APB1Periph | PWM_RCC_APB2Periph | EXTMODULE_RCC_APB2Periph)
 


### PR DESCRIPTION
Bootloader:
- commented usbStart() because of freeze,
- fixed menu,
- finding version works if pointed at bootloader addr,
- booting image from another address probably needs some work: https://community.st.com/s/question/0D53W00000trgpiSAA/how-to-boot-to-random-address-without-vecttaboffset-stm32f072

To sum it up - Still useless, but at least works.

Backlight:
- improved init