### PR TITLE
System DFU Bootloader

### DIFF
--- a/radio/src/targets/flysky/board.h
+++ b/radio/src/targets/flysky/board.h
@@ -74,7 +74,7 @@ extern "C" {
 }
 #endif
 
-#if defined(STM32F0) && defined(BOOT)
+#if defined(STM32F0)
 #define VECTOR_TABLE_SIZE (48)                    // 31 positive vectors, 0 vector, 7 negative vectors and 9 extra
 #define SYSCFG_CFGR1_MEM_MODE__MAIN_FLASH      0  // x0: Main Flash memory mapped at 0x0000 0000
 #define SYSCFG_CFGR1_MEM_MODE__SYSTEM_FLASH    1  // 01: System Flash memory mapped at 0x0000 0000
@@ -306,6 +306,8 @@ uint32_t readTrims(void);
 
 #define TRIMS_PRESSED()                 (readTrims())
 #define KEYS_PRESSED()                  (readKeys())
+
+#define BOOTLOADER_KEYS                0x2100
 
 #define NUM_TRIMS                      4
 #define NUM_TRIMS_KEYS                 (NUM_TRIMS * 2)

--- a/radio/src/targets/flysky/crc_driver.cpp
+++ b/radio/src/targets/flysky/crc_driver.cpp
@@ -10,7 +10,7 @@
 
 void crcInit() {
   CRC->INIT = CRC8_INIT_VAL;
-  CRC_PolynomialSizeSelect(CRC_PolSize_8);
+  CRC->CR = CRC_PolSize_8;
 }
 
 uint8_t crc8_hw(const uint8_t * ptr, uint32_t len) {


### PR DESCRIPTION
- start system DFU Bootloader using trims - OpenTX way
- removed few bytes from crc

I've tested it using `dfu-util` and works as expected.