### PR TITLE
Battery warning can go down to 3.5V

### DIFF
--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -359,7 +359,7 @@ void menuRadioSetup(event_t event)
       case ITEM_SETUP_BATTERY_WARNING:
         lcdDrawTextAlignedLeft(y, STR_BATTERYWARNING);
         putsVolts(RADIO_SETUP_2ND_COLUMN, y, g_eeGeneral.vBatWarn, attr|LEFT);
-        if(attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.vBatWarn, 40, 120); //4-12V
+        if(attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.vBatWarn, 35, 120); //3.5-12V
         break;
 
       case ITEM_SETUP_MEMORY_WARNING:


### PR DESCRIPTION
Battery warning can go down to 3.5V for users with 1S + step-up but with direct batt voltage to adc