### PR TITLE
Move adcRead() to mixer scheduler IRQ to reduce sample jitter

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1163,10 +1163,6 @@ void getADC() {
   }
 #endif
 
-  DEBUG_TIMER_START(debugTimerAdcRead);
-  adcRead();
-  DEBUG_TIMER_STOP(debugTimerAdcRead);
-
   for (uint8_t x = 0; x < NUM_ANALOGS; x++) {
     uint16_t v = getAnalogValue(x) >> (1 - ANALOG_SCALE);
 

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
@@ -76,6 +76,11 @@ extern "C" void MIXER_SCHEDULER_TIMER_IRQHandler(void)
 
   // set next period
   MIXER_SCHEDULER_TIMER->ARR = getMixerSchedulerPeriod() - 1;
+
+  //read ADCs 
+  DEBUG_TIMER_START(debugTimerAdcRead);
+  adcRead();
+  DEBUG_TIMER_STOP(debugTimerAdcRead);
  
   // trigger mixer start
   mixerSchedulerISRTrigger();


### PR DESCRIPTION
Move adcRead() to mixer scheduler IRQ to reduce sample jitter #8480 backport