### PR TITLE
Decrease mixer period for USB Joystick mode, increase report rate #8721

### DIFF
--- a/radio/src/mixer_scheduler.cpp
+++ b/radio/src/mixer_scheduler.cpp
@@ -43,7 +43,11 @@ uint16_t getMixerSchedulerPeriod()
   if (mixerSchedules[EXTERNAL_MODULE].period) {
     return mixerSchedules[EXTERNAL_MODULE].period;
   }
-  
+#if defined(STM32) && !defined(SIMU)
+  if (getSelectedUsbMode() == USB_JOYSTICK_MODE) {
+    return MIXER_SCHEDULER_JOYSTICK_PERIOD_US;
+  }
+#endif
   return MIXER_SCHEDULER_DEFAULT_PERIOD_US;
 }
 

--- a/radio/src/mixer_scheduler.h
+++ b/radio/src/mixer_scheduler.h
@@ -23,7 +23,8 @@
 
 #include <stdint.h>
 
-#define MIXER_SCHEDULER_DEFAULT_PERIOD_US 4000u // 4ms
+#define MIXER_SCHEDULER_DEFAULT_PERIOD_US  4000u // 4ms
+#define MIXER_SCHEDULER_JOYSTICK_PERIOD_US 2000u // 2ms
 
 #define MIN_REFRESH_RATE      1750 /* us */
 #define MAX_REFRESH_RATE     50000 /* us */

--- a/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
+++ b/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
@@ -263,7 +263,7 @@ __ALIGN_BEGIN static const uint8_t USBD_HID_CfgDesc[USB_HID_CONFIG_DESC_SIZ] __A
   0x03,          /*bmAttributes: Interrupt endpoint*/
   HID_IN_PACKET, /*wMaxPacketSize: 4 Byte max */
   0x00,
-  0x0A,          /*bInterval: Polling Interval (10 ms)*/
+  0x01,          /*bInterval: Polling Interval (1 ms)*/
   /* 34 */
 } ;
 


### PR DESCRIPTION
- Decrease mixer period for USB Joystick mode, increase report rate #8721
- Reduce USB polling interval for joystick mode from 10ms to 1ms