### PR TITLE
Fixed an issue where moving right in model menu will skip second tab

### DIFF
--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -251,12 +251,12 @@ void menuModelSelect(event_t event)
     case EVT_ROTARY_RIGHT:
 #endif
     case EVT_KEY_FIRST(KEY_LEFT):
-    case EVT_KEY_FIRST(KEY_RIGHT):
+    case EVT_KEY_BREAK(KEY_RIGHT):
 #if defined(ROTARY_ENCODER_NAVIGATION)
       if ((!IS_ROTARY_RIGHT(event) && !IS_ROTARY_LEFT(event)) || s_editMode < 0) {
 #endif
       if (sub == g_eeGeneral.currModel) {
-        chainMenu((IS_ROTARY_RIGHT(event) || event == EVT_KEY_FIRST(KEY_RIGHT)) ? menuModelSetup : menuTabModel[DIM(menuTabModel)-1]);
+        chainMenu((IS_ROTARY_RIGHT(event) || event == EVT_KEY_BREAK(KEY_RIGHT)) ? menuModelSetup : menuTabModel[DIM(menuTabModel)-1]);
       }
       else {
         AUDIO_WARNING2();


### PR DESCRIPTION
Fixed an issue where moving right in model menu will skip second tab.

Closes #180