### PR TITLE
Crossfire baudrate was ignored!

### DIFF
--- a/radio/src/gui/128x64/radio_hardware.cpp
+++ b/radio/src/gui/128x64/radio_hardware.cpp
@@ -343,15 +343,15 @@ void menuRadioHardware(event_t event)
         break;
 #endif
 
-#if defined(CROSSFIRE) //&& SPORT_MAX_BAUDRATE < 400000
+#if defined(CROSSFIRE)
       case ITEM_RADIO_HARDWARE_SERIAL_BAUDRATE:
-        g_eeGeneral.telemetryBaudrate = editChoice(HW_SETTINGS_COLUMN2, y, STR_MAXBAUDRATE, "\0041.8M921k400k115k", g_eeGeneral.telemetryBaudrate, 0, DIM(CROSSFIRE_BAUDRATES) - 1, attr, event);
+        g_eeGeneral.telemetryBaudrate = editChoice(HW_SETTINGS_COLUMN2, y, STR_MAXBAUDRATE, "\004115k400k921k1.8M", g_eeGeneral.telemetryBaudrate, 0, DIM(CROSSFIRE_BAUDRATES) - 1, attr, event);
         if (attr) {
+          storageDirty(EE_GENERAL);
           if (checkIncDec_Ret && IS_EXTERNAL_MODULE_ON()) {
             pauseMixerCalculations();
             pausePulses();
             EXTERNAL_MODULE_OFF();
-            storageDirty(EE_GENERAL);
             RTOS_WAIT_MS(20); // 20ms so that the pulses interrupt will reinit the frame rate
             telemetryProtocol = 255; // force telemetry port + module reinitialization
             EXTERNAL_MODULE_ON();

--- a/radio/src/targets/flysky/board.h
+++ b/radio/src/targets/flysky/board.h
@@ -184,7 +184,7 @@ uint32_t isBootloaderStart(const uint8_t * buffer);
 #define EXTERNAL_MODULE_ON()            EXTMODULE_PWR_GPIO->BSRR = EXTMODULE_PWR_GPIO_PIN // GPIO_SetBits(EXTMODULE_PWR_GPIO, EXTMODULE_PWR_GPIO_PIN)
 #define EXTERNAL_MODULE_OFF()           EXTMODULE_PWR_GPIO->BRR = EXTMODULE_PWR_GPIO_PIN // GPIO_ResetBits(EXTMODULE_PWR_GPIO, EXTMODULE_PWR_GPIO_PIN)
 #define IS_INTERNAL_MODULE_ON()         (false)
-#define IS_EXTERNAL_MODULE_ON()         (false)
+#define IS_EXTERNAL_MODULE_ON()         (GPIO_ReadInputDataBit(EXTMODULE_PWR_GPIO, EXTMODULE_PWR_GPIO_PIN) == Bit_SET)
 #if defined(INTMODULE_USART)
   #define IS_UART_MODULE(port)          (port == INTERNAL_MODULE)
 #else

--- a/radio/src/targets/flysky/tools/elrsV2.cpp
+++ b/radio/src/targets/flysky/tools/elrsV2.cpp
@@ -642,7 +642,7 @@ static void lcd_title() {
 
   const uint8_t barHeight = 9;
   if (titleShowWarn) {
-    lcdDrawChar(LCD_W, 1, tostring(elrsFlags), RIGHT); 
+    lcdDrawChar(LCD_W - FW - 1, 1, tostring(elrsFlags));
   } else {
     lcdDrawText(LCD_W - 1, 1, goodBadPkt, RIGHT);
     lcdDrawVerticalLine(LCD_W - 10, 0, barHeight, SOLID, INVERS); 

--- a/radio/src/telemetry/telemetry.h
+++ b/radio/src/telemetry/telemetry.h
@@ -109,26 +109,21 @@ extern uint8_t telemetryState;
 #define TELEMETRY_RX_PACKET_SIZE       19  // 9 bytes (full packet), worst case 18 bytes with byte-stuffing (+1)
 #endif
 
-//#if SPORT_MAX_BAUDRATE < 400000
 const uint32_t CROSSFIRE_BAUDRATES[] = {
-  1870000,
-  921600,
-  400000,
   115200,
+  400000,
+  921600,
+  1870000,
 };
 const uint8_t CROSSFIRE_PERIODS[] = {
-  4,
-  4,
-  4,
   16,
+  4,
+  4,
+  4,
 };
-#if SPORT_MAX_BAUDRATE < 400000 || defined(DEBUG)
+
 #define CROSSFIRE_BAUDRATE    CROSSFIRE_BAUDRATES[g_eeGeneral.telemetryBaudrate]
 #define CROSSFIRE_PERIOD      (CROSSFIRE_PERIODS[g_eeGeneral.telemetryBaudrate] * 1000)
-#else
-#define CROSSFIRE_BAUDRATE       400000
-#define CROSSFIRE_PERIOD         4000 /* us; 250 Hz */
-#endif
 
 #define CROSSFIRE_TELEM_MIRROR_BAUDRATE   115200
 


### PR DESCRIPTION
- Crossfire baudrate was ignored!
- ELRSv2 proper flag placement,
- Reversed baudrate order to make it more intuitive,