### PR TITLE
Do not enable serial rx interrupt,

### DIFF
--- a/radio/src/fifo.h
+++ b/radio/src/fifo.h
@@ -21,6 +21,8 @@
 #ifndef _FIFO_H_
 #define _FIFO_H_
 
+#include <inttypes.h>
+
 template <class T, int N>
 class Fifo
 {
@@ -40,7 +42,7 @@ class Fifo
 
     void push(T element)
     {
-      uint32_t next = (widx+1) & (N-1);
+      uint32_t next = nextIndex(widx);
       if (next != ridx) {
         fifo[widx] = element;
         widx = next;
@@ -54,7 +56,7 @@ class Fifo
       }
       else {
         element = fifo[ridx];
-        ridx = (ridx+1) & (N-1);
+        ridx = nextIndex(ridx);
         return true;
       }
     }
@@ -64,23 +66,23 @@ class Fifo
       return (ridx == widx);
     }
 
-    bool isFull()
+    bool isFull() const
     {
-      uint32_t next = (widx+1) & (N-1);
+      uint32_t next = nextIndex(widx);
       return (next == ridx);
     }
 
     void flush()
     {
-      while (!isEmpty()) {};
+      while (!isEmpty());
     }
 
     uint32_t size() const
     {
-      return (N + widx - ridx) & (N-1);
+      return (N + widx - ridx) & (N - 1);
     }
 
-    uint32_t hasSpace(uint32_t n) const
+    bool hasSpace(uint32_t n) const
     {
       return (N > (size() + n));
     }
@@ -100,6 +102,11 @@ class Fifo
     T fifo[N];
     volatile uint32_t widx;
     volatile uint32_t ridx;
+
+    static inline uint32_t nextIndex(uint32_t idx)
+    {
+      return (idx + 1) & (N - 1);
+    }
 };
 
 #endif // _FIFO_H_

--- a/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
@@ -102,7 +102,9 @@ void auxSerialSetup(unsigned int baudrate, bool dma, uint16_t lenght = USART_Wor
   }
   else {
     USART_Cmd(AUX_SERIAL_USART, ENABLE);
+#if !defined(PCBI6X)
     USART_ITConfig(AUX_SERIAL_USART, USART_IT_RXNE, ENABLE);
+#endif
     USART_ITConfig(AUX_SERIAL_USART, USART_IT_TXE, DISABLE);
     NVIC_SetPriority(AUX_SERIAL_USART_IRQn, 7);
     NVIC_EnableIRQ(AUX_SERIAL_USART_IRQn);
@@ -158,7 +160,7 @@ void auxSerialPutc(char c)
   int n = 0;
   while (auxSerialTxFifo.isFull()) {
     delay_ms(1);
-    if (++n > 100) return;
+    if (++n > 10) return;
   }
   auxSerialTxFifo.push(c);
   USART_ITConfig(AUX_SERIAL_USART, USART_IT_TXE, ENABLE);
@@ -251,6 +253,6 @@ extern "C" void AUX_SERIAL_USART_IRQHandler(void)
     status = AUX_SERIAL_USART->SR;
 #endif // STM32F0
   }
-#endif // SBUS
+#endif // PCBI6X
 }
 #endif // AUX_SERIAL


### PR DESCRIPTION
- Do not enable serial rx interrupt.
- Fixed occasional reboots on serial fifo full by reducing wait delay.

It would be much better to increase buffer to 256 bytes.