### PR TITLE
Exclude sensor logs option

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -261,7 +261,7 @@ enum UartModes {
 #if defined(SBUS)
   UART_MODE_SBUS_TRAINER,
 #endif
-#if !defined(PCBI6X)
+#if defined(LUA)
   UART_MODE_LUA,
 #endif
   UART_MODE_COUNT,

--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -133,7 +133,9 @@ enum SensorFields {
   SENSOR_FIELD_ONLYPOSITIVE,
   SENSOR_FIELD_FILTER,
   SENSOR_FIELD_PERSISTENT,
+#if defined(SDCARD)
   SENSOR_FIELD_LOGS,
+#endif
   SENSOR_FIELD_MAX
 };
 
@@ -362,14 +364,14 @@ void menuModelSensor(event_t event)
         }
         break;
 
+#if defined(SDCARD)
       case SENSOR_FIELD_LOGS:
         ON_OFF_MENU_ITEM(sensor->logs, SENSOR_2ND_COLUMN, y, STR_LOGS, attr, event);
         if (attr && checkIncDec_Ret) {
-#if defined(SDCARD)
           logsClose();
-#endif
         }
         break;
+#endif
 
     }
   }

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -268,7 +268,7 @@ void onMainViewMenu(const char *result)
     timerReset(2);
   }
 #endif
-#if !defined(PCBI6X)
+#if defined(SDCARD)
   else if (result == STR_VIEW_NOTES) {
     pushModelNotes();
   }

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1422,11 +1422,7 @@ void doMixerPeriodicUpdates()
         s_cnt_1s -= 10;
         sessionTimer += 1;
         inactivity.counter++;
-#if defined(PCBI6X)
         if ((((uint8_t)inactivity.counter) & 0x07) == 0x01 && g_eeGeneral.inactivityTimer && inactivity.counter > ((uint16_t)g_eeGeneral.inactivityTimer * 60))
-#else
-        if ((((uint8_t)inactivity.counter) & 0x07) == 0x01 && g_eeGeneral.inactivityTimer && g_vbat100mV > 50 && inactivity.counter > ((uint16_t)g_eeGeneral.inactivityTimer * 60))
-#endif
           AUDIO_INACTIVITY();
 
 #if defined(AUDIO) || defined(PCBI6X)

--- a/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
@@ -162,7 +162,7 @@ void auxSerialPutc(char c)
   int n = 0;
   while (auxSerialTxFifo.isFull()) {
     delay_ms(1);
-    if (++n > 10) return;
+    if (++n > 5) return;
   }
   auxSerialTxFifo.push(c);
   USART_ITConfig(AUX_SERIAL_USART, USART_IT_TXE, ENABLE);


### PR DESCRIPTION
- Exclude sensor logs option
- Optimize i2c routine for size.
- Reduce serial tx wait loop.
- Better defines.