### PR TITLE
Use RxNum for AFHDS2A receiver identification

### DIFF
--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -414,7 +414,6 @@ PACK(struct ModuleData {
   uint8_t subType : 3;
   uint8_t invertedSerial : 1;  // telemetry serial inverted from standard
 #if defined(PCBI6X)
-  uint8_t rxID[4];
   uint16_t servoFreq;
 #endif
   int16_t failsafeChannels[MAX_OUTPUT_CHANNELS];
@@ -715,6 +714,7 @@ PACK(struct TrainerData {
   uint8_t slidersConfig : 4;                                        \
   uint8_t potsConfig; /* two bits per pot */                        \
   uint8_t backlightColor;                                           \
+  uint8_t receiverId[16][4]; /* AFHDS2A RxNum */                          \
   swarnstate_t switchUnlockStates;                                  \
   swconfig_t switchConfig;                                          \
   char switchNames[NUM_SWITCHES][LEN_SWITCH_NAME];                  \

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -411,8 +411,8 @@ PACK(struct ModuleData {
   uint8_t channelsStart;
   int8_t channelsCount;      // 0=8 channels
   uint8_t failsafeMode : 4;  // only 3 bits used
-  uint8_t subType : 3;
-  uint8_t invertedSerial : 1;  // telemetry serial inverted from standard
+  uint8_t subType : 4;
+//  uint8_t invertedSerial : 1;  // telemetry serial inverted from standard, not used on PCBI6X
 #if defined(PCBI6X)
   uint16_t servoFreq;
 #endif

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -713,10 +713,9 @@ PACK(struct TrainerData {
   uint8_t auxSerialMode : 4;                                        \
   uint8_t slidersConfig : 4;                                        \
   uint8_t potsConfig; /* two bits per pot */                        \
-  uint8_t backlightColor;                                           \
-  uint8_t receiverId[16][4]; /* AFHDS2A RxNum */                          \
   swarnstate_t switchUnlockStates;                                  \
   swconfig_t switchConfig;                                          \
+  uint8_t receiverId[16][4]; /* AFHDS2A RxNum */                    \
   char switchNames[NUM_SWITCHES][LEN_SWITCH_NAME];                  \
   char anaNames[NUM_STICKS + NUM_POTS + NUM_SLIDERS][LEN_ANA_NAME]; \
   BLUETOOTH_FIELDS
@@ -925,7 +924,6 @@ static inline void check_struct() {
   CHKSIZE(TelemetrySensor, 14);
 
 #if defined(PCBI6X)
-  CHKSIZE(RadioData, 292);
   CHKSIZE(ModuleData, 40);
 #else
   CHKSIZE(ModuleData, 70);
@@ -936,7 +934,10 @@ static inline void check_struct() {
   CHKSIZE(RssiAlarmData, 2);
   CHKSIZE(TrainerData, 16);
 
-#if defined(PCBXLITE)
+#if defined(PCBI6X)
+  CHKSIZE(RadioData, 291);
+  CHKSIZE(ModelData, 2768);
+#elif defined(PCBXLITE)
   CHKSIZE(RadioData, 844);
   CHKSIZE(ModelData, 6025);
 #elif defined(PCBX7)

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -925,7 +925,8 @@ static inline void check_struct() {
   CHKSIZE(TelemetrySensor, 14);
 
 #if defined(PCBI6X)
-  CHKSIZE(ModuleData, 44);
+  CHKSIZE(RadioData, 292);
+  CHKSIZE(ModuleData, 40);
 #else
   CHKSIZE(ModuleData, 70);
 #endif

--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -770,7 +770,7 @@ void putsModelName(coord_t x, coord_t y, char *name, uint8_t id, LcdFlags att)
 void drawSwitch(coord_t x, coord_t y, swsrc_t idx, LcdFlags flags, bool autoBold)
 {
   char s[8];
-  getSwitchString(s, idx);
+  getSwitchPositionName(s, idx);
   if (autoBold && idx != SWSRC_NONE && getSwitch(idx))
     flags |= BOLD;
   lcdDrawText(x, y, s, flags);

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -685,7 +685,7 @@ void putsModelName(coord_t x, coord_t y, char *name, uint8_t id, LcdFlags att)
 void drawSwitch(coord_t x, coord_t y, int32_t idx, LcdFlags flags)
 {
   char s[8];
-  getSwitchString(s, idx);
+  getSwitchPositionName(s, idx);
   lcdDrawText(x, y, s, flags);
 }
 

--- a/radio/src/gui/480x272/lcd.cpp
+++ b/radio/src/gui/480x272/lcd.cpp
@@ -290,7 +290,7 @@ void putsModelName(coord_t x, coord_t y, char * name, uint8_t id, LcdFlags att)
 void drawSwitch(coord_t x, coord_t y, swsrc_t idx, LcdFlags flags)
 {
   char s[8];
-  getSwitchString(s, idx);
+  getSwitchPositionName(s, idx);
   lcdDrawText(x, y, s, flags);
 }
 

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -149,8 +149,11 @@ const mm_protocol_definition *getMultiProtocolDefinition (uint8_t protocol);
 #define MULTIMODULE_OPTIONS_ROW         HIDDEN_ROW
 #endif
 
-
+#if defined(PCBI6X)
+#define MAX_RX_NUM(x)                  (isModuleA7105(x) ? 15 : 63)
+#else
 #define MAX_RX_NUM(x)                  (isModuleDSM2(x) ? 20 : isModuleMultimodule(x) ? MULTI_MAX_RX_NUM(x) : 63)
+#endif
 #define IS_D8_RX(x)                    (g_model.moduleData[x].rfProtocol == RF_PROTO_D8)
 #define IS_R9M_OR_XJTD16(x)            ((isModuleXJT(x) && g_model.moduleData[x].rfProtocol== RF_PROTO_X16) || isModuleR9M(x))
 

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -35,7 +35,7 @@
 #define WARN_MEM (!(g_eeGeneral.warnOpts & WARN_MEM_BIT))
 #define BEEP_VAL ((g_eeGeneral.warnOpts & WARN_BVAL_BIT) >> 3)
 
-#define EEPROM_VER 220
+#define EEPROM_VER 221
 #define FIRST_CONV_EEPROM_VER 216
 
 #define GET_PPM_POLARITY(idx) g_model.moduleData[idx].ppm.pulsePol

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -226,7 +226,7 @@ char * getGVarString(char * dest, int idx)
   return dest;
 }
 
-char * getSwitchString(char * dest, swsrc_t idx)
+char * getSwitchPositionName(char * dest, swsrc_t idx)
 {
   if (idx == SWSRC_NONE) {
     return getStringAtIndex(dest, STR_VSWITCHES, 0);
@@ -284,15 +284,9 @@ char * getSwitchString(char * dest, swsrc_t idx)
   }
 #endif
 
-#if defined(PCBSKY9X)
-  else if (idx <= SWSRC_REa) {
-    getStringAtIndex(s, STR_VSWITCHES, IDX_TRIMS_IN_STR_VSWITCHES+idx-SWSRC_FIRST_TRIM);
-  }
-#else
   else if (idx <= SWSRC_LAST_TRIM) {
     getStringAtIndex(s, STR_VSWITCHES, IDX_TRIMS_IN_STR_VSWITCHES+idx-SWSRC_FIRST_TRIM);
   }
-#endif
 
   else if (idx <= SWSRC_LAST_LOGICAL_SWITCH) {
     *s++ = 'L';
@@ -369,7 +363,7 @@ char * getSourceString(char * dest, mixsrc_t idx)
     }
   }
   else if (idx <= MIXSRC_LAST_LOGICAL_SWITCH) {
-    getSwitchString(dest, SWSRC_SW1 + idx - MIXSRC_SW1);
+    getSwitchPositionName(dest, SWSRC_SW1 + idx - MIXSRC_SW1);
   }
   else if (idx <= MIXSRC_LAST_TRAINER) {
     strAppendStringWithIndex(dest, STR_PPM_TRAINER, idx - MIXSRC_FIRST_TRAINER + 1);
@@ -416,10 +410,10 @@ char * strAppendUnsigned(char * dest, uint32_t value, uint8_t digits, uint8_t ra
     }
   }
   uint8_t idx = digits;
-  while(idx > 0) {
-    uint32_t rem = value % radix;
-    dest[--idx] = (rem >= 10 ? 'A'-10 : '0') + rem;
-    value /= radix;
+  while (idx > 0) {
+    div_t qr = div(value, radix);
+    dest[--idx] = (qr.rem >= 10 ? 'A' - 10 : '0') + qr.rem;
+    value = qr.quot;
   }
   dest[digits] = '\0';
   return &dest[digits];

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -35,7 +35,7 @@ char * strAppendStringWithIndex(char * dest, const char * s, int idx);
 char * getTimerString(char * dest, int32_t tme, uint8_t hours=0);
 char * getCurveString(char * dest, int idx);
 char * getGVarString(char * dest, int idx);
-char * getSwitchString(char * dest, swsrc_t idx);
+char * getSwitchPositionName(char * dest, swsrc_t idx);
 char * getSourceString(char * dest, mixsrc_t idx);
 #endif
 

--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -106,7 +106,6 @@ void usbInit()
 
 void usbStart()
 {
-  watchdogSuspend(200); // 2s, PCBI6X fix for occasional reboots on joystick connect
   switch (getSelectedUsbMode()) {
 #if !defined(BOOT)
     case USB_JOYSTICK_MODE:

--- a/radio/src/targets/flysky/AFHDS2A_a7105.cpp
+++ b/radio/src/targets/flysky/AFHDS2A_a7105.cpp
@@ -114,7 +114,7 @@ static void AFHDS2A_build_bind_packet(void) {
     case AFHDS2A_BIND4:
       packet[0] = 0xbc;
       if (phase == AFHDS2A_BIND4) {
-        memcpy(&packet[5], &g_eeGeneral.receiverId[&g_model.header.modelId[INTERNAL_MODULE]], 4);
+        memcpy(&packet[5], &g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]][0], 4);
         memset(&packet[11], 0xff, 16);
       }
       packet[9] = phase - 1;
@@ -128,7 +128,7 @@ static void AFHDS2A_build_bind_packet(void) {
 
 void AFHDS2A_build_packet(const uint8_t type) {
   memcpy(&packet[1], ID.rx_tx_addr, sizeof(ID.rx_tx_addr));
-  memcpy(&packet[5], &g_eeGeneral.receiverId[&g_model.header.modelId[INTERNAL_MODULE]], 4);
+  memcpy(&packet[5], &g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]][0], 4);
   switch (type) {
     case AFHDS2A_PACKET_STICKS:
       packet[0] = 0x58;
@@ -309,7 +309,7 @@ EndSendBIND123_:  //-----------------------------------------------------------
 ResBIND123_:  //-----------------------------------------------------------
   A7105_ReadData(AFHDS2A_RXPACKET_SIZE);
   if ((packet[0] == 0xbc) & (packet[9] == 0x01)) {
-    memcpy(&g_eeGeneral.receiverId[&g_model.header.modelId[INTERNAL_MODULE]], &packet[5], 4);
+    memcpy(&g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]][0], &packet[5], 4);
     RadioState = (RadioState & 0xF0) | AFHDS2A_BIND4;
     bind_phase = 0;
     SETBIT(RadioState, SEND_RES, SEND);

--- a/radio/src/targets/flysky/AFHDS2A_a7105.cpp
+++ b/radio/src/targets/flysky/AFHDS2A_a7105.cpp
@@ -114,7 +114,7 @@ static void AFHDS2A_build_bind_packet(void) {
     case AFHDS2A_BIND4:
       packet[0] = 0xbc;
       if (phase == AFHDS2A_BIND4) {
-        memcpy(&packet[5], &g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]][0], 4);
+        memcpy(&packet[5], &g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]], 4);
         memset(&packet[11], 0xff, 16);
       }
       packet[9] = phase - 1;
@@ -128,7 +128,7 @@ static void AFHDS2A_build_bind_packet(void) {
 
 void AFHDS2A_build_packet(const uint8_t type) {
   memcpy(&packet[1], ID.rx_tx_addr, sizeof(ID.rx_tx_addr));
-  memcpy(&packet[5], &g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]][0], 4);
+  memcpy(&packet[5], &g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]], 4);
   switch (type) {
     case AFHDS2A_PACKET_STICKS:
       packet[0] = 0x58;
@@ -309,7 +309,7 @@ EndSendBIND123_:  //-----------------------------------------------------------
 ResBIND123_:  //-----------------------------------------------------------
   A7105_ReadData(AFHDS2A_RXPACKET_SIZE);
   if ((packet[0] == 0xbc) & (packet[9] == 0x01)) {
-    memcpy(&g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]][0], &packet[5], 4);
+    memcpy(&g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]], &packet[5], 4);
     RadioState = (RadioState & 0xF0) | AFHDS2A_BIND4;
     bind_phase = 0;
     SETBIT(RadioState, SEND_RES, SEND);

--- a/radio/src/targets/flysky/AFHDS2A_a7105.cpp
+++ b/radio/src/targets/flysky/AFHDS2A_a7105.cpp
@@ -114,7 +114,7 @@ static void AFHDS2A_build_bind_packet(void) {
     case AFHDS2A_BIND4:
       packet[0] = 0xbc;
       if (phase == AFHDS2A_BIND4) {
-        memcpy(&packet[5], &g_model.moduleData[INTERNAL_MODULE].rxID, 4);
+        memcpy(&packet[5], &g_eeGeneral.receiverId[&g_model.header.modelId[INTERNAL_MODULE]], 4);
         memset(&packet[11], 0xff, 16);
       }
       packet[9] = phase - 1;
@@ -128,7 +128,7 @@ static void AFHDS2A_build_bind_packet(void) {
 
 void AFHDS2A_build_packet(const uint8_t type) {
   memcpy(&packet[1], ID.rx_tx_addr, sizeof(ID.rx_tx_addr));
-  memcpy(&packet[5], g_model.moduleData[INTERNAL_MODULE].rxID, sizeof(g_model.moduleData[INTERNAL_MODULE].rxID));
+  memcpy(&packet[5], &g_eeGeneral.receiverId[&g_model.header.modelId[INTERNAL_MODULE]], 4);
   switch (type) {
     case AFHDS2A_PACKET_STICKS:
       packet[0] = 0x58;
@@ -221,7 +221,7 @@ void ActionAFHDS2A(void) {
         TRACE("Bind done!");
         moduleFlag[INTERNAL_MODULE] = MODULE_NORMAL_MODE;
         s_editMode = EDIT_SELECT_MENU;
-        storageDirty(EE_MODEL);  // Save RX_ID
+        storageDirty(EE_GENERAL);  // Save receiverId
         BIND_STOP;
       }
     }
@@ -309,7 +309,7 @@ EndSendBIND123_:  //-----------------------------------------------------------
 ResBIND123_:  //-----------------------------------------------------------
   A7105_ReadData(AFHDS2A_RXPACKET_SIZE);
   if ((packet[0] == 0xbc) & (packet[9] == 0x01)) {
-    memcpy(&g_model.moduleData[INTERNAL_MODULE].rxID, &packet[5], sizeof(g_model.moduleData[INTERNAL_MODULE].rxID));
+    memcpy(&g_eeGeneral.receiverId[&g_model.header.modelId[INTERNAL_MODULE]], &packet[5], 4);
     RadioState = (RadioState & 0xF0) | AFHDS2A_BIND4;
     bind_phase = 0;
     SETBIT(RadioState, SEND_RES, SEND);

--- a/radio/src/tasks.h
+++ b/radio/src/tasks.h
@@ -26,7 +26,7 @@
 // stack sizes should be in multiples of 8 for better alignment
 // expressed in integers resulting size is 4 times bigger
 #if defined(STM32F0)
-#define MENUS_STACK_SIZE       888
+#define MENUS_STACK_SIZE       880
 #else
 #define MENUS_STACK_SIZE       2048
 #endif


### PR DESCRIPTION
- [x] test, 
- [x] breaks eeprom version (version bump ~~or conversion~~).

Closes: #263 