### PR TITLE
Refactored ModuleData

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -812,9 +812,9 @@ void menuModelSetup(event_t event)
         break;
         case ITEM_MODEL_INTERNAL_MODULE_SERVOFREQ:
         lcdDrawTextAlignedLeft(y, INDENT "Servo freq");
-        lcdDrawNumber(MODEL_SETUP_2ND_COLUMN, y, g_model.moduleData[INTERNAL_MODULE].servoFreq, attr|LEADING0|LEFT, 3);
+        lcdDrawNumber(MODEL_SETUP_2ND_COLUMN, y, g_model.moduleData[INTERNAL_MODULE].afhds2a.servoFreq, attr|LEADING0|LEFT, 3);
         if (attr) {
-          CHECK_INCDEC_MODELVAR(event, g_model.moduleData[INTERNAL_MODULE].servoFreq, 50, 400);
+          CHECK_INCDEC_MODELVAR(event, g_model.moduleData[INTERNAL_MODULE].afhds2a.servoFreq, 50, 400);
         }
         break;
   

--- a/radio/src/gui/128x64/popups.cpp
+++ b/radio/src/gui/128x64/popups.cpp
@@ -52,7 +52,7 @@ void drawAlertBox(const char * title, const char * text, const char * action)
 {
   lcdClear();
 
-#if defined(PCBI6X_ELRSV3) && defined(TRANSLATIONS_CZ) // not enough flash space
+#if defined(PCBI6X_ELRSV3) && defined(TRANSLATIONS_PT) // not enough flash space
   lcdDrawRect(2, 2, 32 - 4, 32 - 4);
   lcdDrawText(11, 6, "x", DBLSIZE);
 #else

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -445,10 +445,11 @@ enum MMRFrskySubtypes {
   MM_RF_FRSKY_SUBTYPE_D16_LBT_8CH
 };
 
-#define HAS_RF_PROTOCOL_FAILSAFE(rf) ((rf) == RF_PROTO_X16)
 #if defined(PCBI6X)
+#define HAS_RF_PROTOCOL_FAILSAFE(rf) (1) /*((rf) == RF_I6X_PROTO_AFHDS2A)*/
 #define HAS_RF_PROTOCOL_MODELINDEX(rf) (1)
 #else
+#define HAS_RF_PROTOCOL_FAILSAFE(rf) ((rf) == RF_PROTO_X16)
 #define HAS_RF_PROTOCOL_MODELINDEX(rf) (((rf) == RF_PROTO_X16) || ((rf) == RF_PROTO_LR12))
 #endif
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -468,8 +468,8 @@ void modelDefault(uint8_t id) {
   g_model.moduleData[INTERNAL_MODULE].type = MODULE_TYPE_AFHDS2A_SPI;
   g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
   g_model.moduleData[INTERNAL_MODULE].channelsCount = MAX_OUTPUT_CHANNELS;
-  g_model.moduleData[INTERNAL_MODULE].servoFreq = 50;
   g_model.moduleData[INTERNAL_MODULE].subType = AFHDS2A_SUBTYPE_PWM_IBUS;
+  g_model.moduleData[INTERNAL_MODULE].afhds2a.servoFreq = 50;
 #endif
 
 #if defined(PCBXLITE)

--- a/radio/src/targets/flysky/AFHDS2A_a7105.cpp
+++ b/radio/src/targets/flysky/AFHDS2A_a7105.cpp
@@ -169,14 +169,8 @@ void AFHDS2A_build_packet(const uint8_t type) {
       packet[0] = 0xaa;
       packet[9] = 0xfd;
       packet[10] = 0xff;
-
-      if (g_model.moduleData[INTERNAL_MODULE].servoFreq < 50 ||
-          g_model.moduleData[INTERNAL_MODULE].servoFreq > 400) {
-        g_model.moduleData[INTERNAL_MODULE].servoFreq = 50;  // default is 50Hz
-      }
-
-      packet[11] = g_model.moduleData[INTERNAL_MODULE].servoFreq;
-      packet[12] = g_model.moduleData[INTERNAL_MODULE].servoFreq >> 8;
+      packet[11] = g_model.moduleData[INTERNAL_MODULE].afhds2a.servoFreq;
+      packet[12] = g_model.moduleData[INTERNAL_MODULE].afhds2a.servoFreq >> 8;
       if (g_model.moduleData[INTERNAL_MODULE].subType & (AFHDS2A_SUBTYPE_PPM_IBUS & AFHDS2A_SUBTYPE_PPM_SBUS)) {
         packet[13] = 0x01;  // PPM output enabled
       } else {

--- a/tools/build-flysky.py
+++ b/tools/build-flysky.py
@@ -53,7 +53,7 @@ translations = [
     "CZ",
     "DE",
     "ES",
-    # "PT",
+    "PT",
     "NL",
     "SE",
     "FI",


### PR DESCRIPTION
* refactored ModuleData for size and generated code size,
* don't validate AFHDS2A servoFreq twice,
* store AFHDS2A servoFreq in union,
* reenabled PT translation builds,
* fix HAS_RF_PROTOCOL_FAILSAFE implementation