### PR TITLE
Fixed hardware menus definition,

### DIFF
--- a/radio/src/gui/128x64/model_input_edit.cpp
+++ b/radio/src/gui/128x64/model_input_edit.cpp
@@ -21,7 +21,6 @@
 #include "opentx.h"
 
 #define EXPO_ONE_2ND_COLUMN (7*FW+3*FW+2)
-#define EXPO_ONE_FM_WIDTH   (5*FW)
 
 int expoFn(int x)
 {
@@ -82,6 +81,11 @@ void menuModelExpoOne(event_t event)
     pushMenu(menuChannelsView);
     killEvents(event);
   }
+#elif defined(PCBI6X)
+  if (event == EVT_KEY_LONG(KEY_RIGHT)) {
+    pushMenu(menuChannelsView);
+    killEvents(event);
+  }
 #endif
   ExpoData * ed = expoAddress(s_currIdx);
   drawSource(PSIZE(TR_MENUINPUTS)*FW+FW, 0, MIXSRC_FIRST_INPUT+ed->chn, 0);
@@ -111,9 +115,9 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_SOURCE:
-        lcdDrawTextAlignedLeft(y, NO_INDENT(STR_SOURCE));
+        lcdDrawTextAlignedLeft(y, STR_SOURCE);
         drawSource(EXPO_ONE_2ND_COLUMN, y, ed->srcRaw, RIGHT|STREXPANDED|attr);
-        if (attr) ed->srcRaw = checkIncDec(event, ed->srcRaw, INPUTSRC_FIRST, INPUTSRC_LAST, EE_MODEL|INCDEC_SOURCE|NO_INCDEC_MARKS, isInputSourceAvailable);
+        if (attr) ed->srcRaw = checkIncDec(event, ed->srcRaw, INPUTSRC_FIRST, INPUTSRC_LAST, EE_MODEL|INCDEC_SOURCE|NO_INCDEC_MARKS, isSourceAvailableInInputs);
         break;
 
       case EXPO_FIELD_SCALE:
@@ -128,7 +132,7 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_OFFSET:
-        lcdDrawTextAlignedLeft(y, NO_INDENT(STR_OFFSET));
+        lcdDrawTextAlignedLeft(y, STR_OFFSET);
         ed->offset = GVAR_MENU_ITEM(EXPO_ONE_2ND_COLUMN, y, ed->offset, -100, 100, RIGHT | attr, 0, event);
         break;
 

--- a/radio/src/gui/128x64/model_mix_edit.cpp
+++ b/radio/src/gui/128x64/model_mix_edit.cpp
@@ -95,6 +95,11 @@ void menuModelMixOne(event_t event)
     pushMenu(menuChannelsView);
     killEvents(event);
   }
+#elif defined(PCBI6X)
+  if (event == EVT_KEY_LONG(KEY_RIGHT)) {
+    pushMenu(menuChannelsView);
+    killEvents(event);
+  }
 #endif
   MixData * md2 = mixAddress(s_currIdx) ;
   putsChn(PSIZE(TR_MIXER)*FW+FW, 0, md2->destCh+1,0);

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1111,10 +1111,10 @@ void menuModelSetup(event_t event)
             xOffsetBind = 0;
             lcdDrawTextAlignedLeft(y, STR_RECEIVER);
             if (attr) l_posHorz += 1;
-          } else if (isModuleCrossfire(moduleIdx)) {
-            lcdDrawTextAlignedLeft(y, STR_RECEIVER);
+//          } else if (isModuleCrossfire(moduleIdx)) {
+//            lcdDrawTextAlignedLeft(y, STR_RECEIVER);
           } else {
-            lcdDrawTextAlignedLeft(y, STR_RECEIVER_NUM);
+            lcdDrawTextAlignedLeft(y, STR_RECEIVER);
           }
           if (isModulePXX(moduleIdx) || isModuleDSM2(moduleIdx) || isModuleMultimodule(moduleIdx) || isModuleCrossfire(moduleIdx) || isModuleA7105(moduleIdx)) {
             if (xOffsetBind)
@@ -1570,7 +1570,7 @@ void menuModelFailsafe(event_t event)
     }
 
     // Gauge
-#if !defined(PCBX7)  // X7 LCD doesn't like too many horizontal lines
+#if !defined(PCBX7) && !defined(PCBI6X) // X7  & i6X LCD doesn't like too many horizontal lines
     lcdDrawRect(x+LCD_W-3-wbar, y, wbar+1, 6);
 #endif
     const uint8_t lenChannel = limit<uint8_t>(1, (abs(channelValue) * wbar/2 + lim/2) / lim, wbar/2);

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -136,13 +136,11 @@ void onCustomFunctionsMenu(const char * result)
     memset(cfn, 0, sizeof(CustomFunctionData));
     storageDirty(eeFlags);
   }
-#if !defined(PCBI6X)
   else if (result == STR_DELETE) {
     memmove(cfn, cfn+1, (MAX_SPECIAL_FUNCTIONS-sub-1)*sizeof(CustomFunctionData));
     memset(&g_model.customFn[MAX_SPECIAL_FUNCTIONS-1], 0, sizeof(CustomFunctionData));
     storageDirty(eeFlags);
   }
-#endif
 }
 #endif // PCBTARANIS, PCBI6X
 
@@ -169,8 +167,6 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
     if (!CFN_EMPTY(cfn))
 #if !defined(PCBI6X)
       POPUP_MENU_ADD_ITEM(STR_COPY);
-#endif // PCBI6X
-#if defined(SDCARD)
     if (clipboard.type == CLIPBOARD_TYPE_CUSTOM_FUNCTION && isAssignableFunctionAvailable(clipboard.data.cfn.func))
       POPUP_MENU_ADD_ITEM(STR_PASTE);
 #endif
@@ -178,14 +174,12 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
       POPUP_MENU_ADD_ITEM(STR_INSERT);
     if (!CFN_EMPTY(cfn))
       POPUP_MENU_ADD_ITEM(STR_CLEAR);
-#if !defined(PCBI6X)
     for (int i=sub+1; i<MAX_SPECIAL_FUNCTIONS; i++) {
       if (!CFN_EMPTY(&functions[i])) {
         POPUP_MENU_ADD_ITEM(STR_DELETE);
         break;
       }
     }
-#endif
     POPUP_MENU_START(onCustomFunctionsMenu);
   }
 #if defined(PCBXLITE)

--- a/radio/src/gui/128x64/radio_hardware.cpp
+++ b/radio/src/gui/128x64/radio_hardware.cpp
@@ -215,11 +215,13 @@ void menuRadioHardware(event_t event)
 #if defined(CROSSFIRE)
     0 /* max bauds */,
 #endif
+    0 /* Aux serial mode */,
     BLUETOOTH_ROWS
     0 /*jitter filter*/,
 #if defined(MENU_DIAG_ANAS_KEYS)
     1 /* debugs */,
 #endif
+    0 /* factory reset */
   });
 
   uint8_t sub = menuVerticalPosition - HEADER_LINE;

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -156,20 +156,30 @@ void menuRadioSetup(event_t event)
     0, LABEL(ALARMS), 0, CASE_CAPACITY(0)
     CASE_PCBSKY9X(0)
     0, 0, 0, 0, IF_ROTARY_ENCODERS(0)
-    LABEL(BACKLIGHT), 0, 0, /*0,*/ CASE_PWM_BACKLIGHT(0)
-    CASE_PWM_BACKLIGHT(0)
+    LABEL(BACKLIGHT), 0, 0,
+#if defined(PCBI6X_BACKLIGHT_MOD)
     0,
+#endif
+    CASE_PWM_BACKLIGHT(0)
+    CASE_PWM_BACKLIGHT(0)
+    0, /* alarm */
     CASE_SPLASH_PARAM(0)
 #if defined(PXX2)
     0 /* owner registration ID */,
 #endif
     CASE_GPS(0)
-    0, CASE_GPS(0)
+    /*0, rtc */
+    CASE_GPS(0)
     CASE_PXX(0)
-    0, 0, IF_FAI_CHOICE(0)
+    /*0, 0,*/ /* voice language, imperial */
+    IF_FAI_CHOICE(0)
     0,
     CASE_STM32(0) // USB mode
-    0, COL_TX_MODE, 0, 1/*to force edit mode*/});
+#if defined(PCBI6X) && !defined(PCBI6X_USB_VBUS)
+    0,
+#endif
+    0,
+    COL_TX_MODE, 0, 1/*to force edit mode*/});
 
   if (event == EVT_ENTRY) {
     reusableBuffer.generalSettings.stickMode = g_eeGeneral.stickMode;

--- a/radio/src/gui/common/stdlcd/widgets.cpp
+++ b/radio/src/gui/common/stdlcd/widgets.cpp
@@ -24,7 +24,7 @@ void drawStringWithIndex(coord_t x, coord_t y, const char * str, uint8_t idx, Lc
 {
   if (flags & RIGHT) {
     lcdDrawNumber(x, y, idx, flags);
-    lcdDrawText(x-FWNUM, y, str, flags & ~LEADING0);
+    lcdDrawText(lcdNextPos, y, str, flags & ~LEADING0);
   }
   else {
     lcdDrawText(x, y, str, flags & ~LEADING0);

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -39,7 +39,7 @@ int getFirstAvailable(int min, int max, IsValueAvailable isValueAvailable);
 
 bool isTrimModeAvailable(int mode);
 bool isInputAvailable(int input);
-bool isInputSourceAvailable(int source);
+bool isSourceAvailableInInputs(int source);
 bool isThrottleSourceAvailable(int source);
 bool isLogicalSwitchFunctionAvailable(int function);
 bool isLogicalSwitchAvailable(int index);

--- a/radio/src/gui/gui_common_arm.cpp
+++ b/radio/src/gui/gui_common_arm.cpp
@@ -211,7 +211,7 @@ bool isSourceAvailableInCustomSwitches(int source) {
   return result;
 }
 
-bool isInputSourceAvailable(int source) {
+bool isSourceAvailableInInputs(int source) {
   if (source >= MIXSRC_FIRST_POT && source <= MIXSRC_LAST_POT) {
     return IS_POT_SLIDER_AVAILABLE(POT1 + source - MIXSRC_FIRST_POT);
   }

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -369,7 +369,7 @@ extern uint8_t channel_order(uint8_t x);
 
 #if defined(PCBHORUS)
   #define SPLASH_TIMEOUT               0 /* we use the splash duration to load stuff from the SD */
-#elif defined(PCBTARANIS)
+#elif defined(PCBTARANIS) || defined(PCBI6X)
   #define SPLASH_TIMEOUT               (g_eeGeneral.splashMode==-4 ? 1500 : (g_eeGeneral.splashMode<=0 ? (400-g_eeGeneral.splashMode*200) : (400-g_eeGeneral.splashMode*100)))
 #else
   #define SPLASH_TIMEOUT               (4*100)  // 4 seconds


### PR DESCRIPTION
- fixed hardware menus definition,
- fixed radio setup menu focus,
- enabled DELETE action for special functions menu,
- unified Receiver row name to be always "Receiver" instead of "RxNum", 
- fixed splash screen delay option,
- enabled channels monitor shortcut for model input edit and mixer edit by long press BIND button,
- menu improvements backport (fixes #7036)