### PR TITLE
Add AFHDS2A telemetry CRC check

### DIFF
--- a/radio/src/pulses/pulses_arm.cpp
+++ b/radio/src/pulses/pulses_arm.cpp
@@ -320,7 +320,7 @@ bool setupPulses(uint8_t port) {
         break;
       case PROTOCOL_CHANNELS_AFHDS2A_SPI:
         init_afhds2a(port);
-        mixerSchedulerSetPeriod(INTERNAL_MODULE, 3860);
+        mixerSchedulerSetPeriod(INTERNAL_MODULE, 3850);
         break;
       default:
         init_no_pulses(port);

--- a/radio/src/targets/flysky/A7105_SPI.cpp
+++ b/radio/src/targets/flysky/A7105_SPI.cpp
@@ -54,34 +54,12 @@ void SPI_Write(uint8_t command)
 {//working OK
 	while((SPI1->SR & SPI_SR_BSY));
 	*(__IO uint8_t *)&SPI1->DR = command;					//Write the first data item to be transmitted into the SPI_DR register (this clears the TXE flag).
-	// #ifdef DEBUG_SPI
-	// 	debug("%02X ",command);
-	// #endif
+	#ifdef DEBUG_SPI
+		debug("%02X ",command);
+	#endif
 	while (!(SPI1->SR & SPI_SR_RXNE));
 	command = (uint8_t)SPI1->DR;					// ... and read the last received data.
 }
-
-// uint8_t SPI_SDI_Read()
-// {	
-// 	uint8_t rx=0;
-// 	// cli();	//Fix Hubsan droputs??
-// 	while(!(SPI1->SR & SPI_SR_TXE));
-// 	while((SPI1->SR & SPI_SR_BSY));	
-// 	//	
-// 	SPI_DISABLE();
-// 	SPI_SET_BIDIRECTIONAL();
-// 	volatile uint8_t x = SPI1->DR;
-// 	(void)x;
-// 	SPI_ENABLE();
-// 	//
-// 	SPI_DISABLE();				  
-// 	while(!(SPI1->SR& SPI_SR_RXNE));
-// 	rx=(uint8_t)SPI1->DR;
-// 	SPI_SET_UNIDIRECTIONAL();
-// 	SPI_ENABLE();
-// 	// sei();//fix Hubsan dropouts??
-// 	return rx;
-// }
 
 uint8_t SPI_SDI_Read() 
 {
@@ -91,22 +69,12 @@ uint8_t SPI_SDI_Read()
     //   dummy = (uint8_t)(READ_REG(SPI1->DR));
     // }
     // (void)dummy;
-//	__disable_irq(); // cli();	//Fix Hubsan droputs??
 	while(!(SPI1->SR & SPI_SR_TXE));
 	while((SPI1->SR & SPI_SR_BSY));
-	// SPI_DISABLE();
-// 	SPI_SET_BIDIRECTIONAL();
-// 	volatile uint8_t x = SPI1->DR;
-// 	(void)x;
-	// SPI_ENABLE();
-	//
-	// SPI_DISABLE();
+
     *(__IO uint8_t *)&SPI1->DR = 0x00; // not present in multi
     while(!(SPI1->SR & SPI_SR_RXNE));
     rx=(uint8_t)SPI1->DR;
-// 	SPI_SET_UNIDIRECTIONAL();
-	// SPI_ENABLE();
-//	__enable_irq(); // sei();//fix Hubsan dropouts??
 	return rx;
 }
 
@@ -146,17 +114,6 @@ void SPI_ENABLE()
 void SPI_DISABLE()
 {
 	SPI1->CR1 &= ~SPI_CR1_SPE;
-}
-
-void SPI_SET_BIDIRECTIONAL()
-{
-	SPI1->CR1 |= SPI_CR1_BIDIMODE;
-	SPI1->CR1  &= ~ SPI_CR1_BIDIOE;//receive only
-}
-
-void SPI_SET_UNIDIRECTIONAL()
-{
-	SPI1->CR1 &= ~SPI_CR1_BIDIMODE;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/radio/src/targets/flysky/A7105_SPI.cpp
+++ b/radio/src/targets/flysky/A7105_SPI.cpp
@@ -20,9 +20,6 @@
 #include "stdint.h"
 #include "iface_a7105.h"
 #include "hal.h"
-
-#define NOP() __asm__ __volatile__("nop")
-
 volatile uint8_t RadioState;
 
 uint8_t protocol_flags=0;
@@ -77,45 +74,6 @@ uint8_t SPI_SDI_Read()
     rx=(uint8_t)SPI1->DR;
 	return rx;
 }
-
-// void SPI_RADIO_SendBlock(uint8_t *BufferPtr, uint16_t Size) {
-//   while (Size) {
-//     while ((SPI1->SR & SPI_SR_TXE) == 0);
-// //    while ((SPI1->SR & SPI_SR_BSY) != 0);
-//     *(__IO uint8_t *)&SPI1->DR = *BufferPtr++;
-//     Size--;
-//   }
-//   while (SPI1->SR & (SPI_SR_FTLVL | SPI_SR_BSY));
-// }
-/*---------------------------------------------------------------------------*/
-// void SPI_RADIO_ReceiveBlock(uint8_t *BufferPtr, uint16_t Size) {
-//   uint8_t dummy;
-//   while (Size) {
-//     while ((SPI1->SR & SPI_SR_FRLVL) != 0) {
-//       dummy = (uint8_t)(READ_REG(SPI1->DR));
-//     }
-//     (void)dummy;
-//     while ((SPI1->SR & SPI_SR_TXE) == 0);
-//     while ((SPI1->SR & SPI_SR_BSY) != 0);
-//     *(__IO uint8_t *)&SPI1->DR = 0x00;
-//     while ((SPI1->SR & SPI_SR_RXNE) == 0);
-
-//     *BufferPtr++ = (uint8_t)(READ_REG(SPI1->DR));
-//     Size--;
-//   }
-// //   while ((SPI1->SR & SPI_SR_BSY) != 0);
-// }
-
-void SPI_ENABLE()
-{
-	SPI1->CR1 |= SPI_CR1_SPE;
-}
-
-void SPI_DISABLE()
-{
-	SPI1->CR1 &= ~SPI_CR1_SPE;
-}
-
 /*---------------------------------------------------------------------------*/
 inline void a7105_csn_on(void) {RF_SCN_GPIO_PORT->BSRR = RF_SCN_SET_PIN;}
 inline void a7105_csn_off(void) {RF_SCN_GPIO_PORT->BSRR = RF_SCN_RESET_PIN;}
@@ -199,7 +157,7 @@ void A7105_ReadData(uint8_t len) {
 void A7105_WriteReg(uint8_t address, uint8_t data) {
 	A7105_CSN_off;
 	SPI_Write(address); 
-	NOP();
+//	NOP();
 	SPI_Write(data);  
 	A7105_CSN_on;
 }

--- a/radio/src/targets/flysky/A7105_SPI.cpp
+++ b/radio/src/targets/flysky/A7105_SPI.cpp
@@ -28,8 +28,6 @@ volatile uint8_t RadioState;
 uint8_t protocol_flags=0;
 uint8_t prev_power=0xFD; // unused power value
 
-volatile uint8_t a7105_spi_error_flag = 0;
-
 // reuse telemetryRxBuffer for native AFHDS2A support
 uint8_t *packet = &telemetryRxBuffer[0];
 
@@ -88,7 +86,6 @@ void SPI_Write(uint8_t command)
 uint8_t SPI_SDI_Read() 
 {
 	uint8_t rx=0;
-	// a7105_spi_error_flag |= 2;
 	// uint8_t dummy;
     // while ((SPI1->SR & SPI_SR_FRLVL) != 0) { // not present in multi
     //   dummy = (uint8_t)(READ_REG(SPI1->DR));
@@ -106,10 +103,6 @@ uint8_t SPI_SDI_Read()
 	// SPI_DISABLE();
     *(__IO uint8_t *)&SPI1->DR = 0x00; // not present in multi
     while(!(SPI1->SR & SPI_SR_RXNE));
-	  a7105_spi_error_flag = SPI1->SR & ( SPI_SR_OVR | SPI_SR_MODF);
-    if (SPI1->SR & ( SPI_SR_OVR | SPI_SR_MODF)) {
-      auxSerialPutc("E");
-    }
     rx=(uint8_t)SPI1->DR;
 // 	SPI_SET_UNIDIRECTIONAL();
 	// SPI_ENABLE();

--- a/radio/src/targets/flysky/A7105_SPI.cpp
+++ b/radio/src/targets/flysky/A7105_SPI.cpp
@@ -307,15 +307,18 @@ void A7105_Sleep(void) {
 	A7105_WriteReg(A7105_0C_GPIO2_PIN_II, 0x33);
 }
 
+#define ID_NORMAL  0x55201041 // used by Multiprotocol Module
+#define ID_NORMAL2 0x5475C52A // used by DeviationTX & erFly6
 void A7105_Init(void)
 {
 	uint8_t *A7105_Regs = 0;
 //	uint8_t vco_calibration0, vco_calibration1;
-/*****************************************************************************/
-	A7105_Reset();
-    delay_ms(1);
-/*****************************************************************************/
-	A7105_WriteID(0x5475c52A); //0x2Ac57554
+
+  A7105_Reset();
+  delay_ms(1);
+
+	A7105_WriteID(ID_NORMAL2);
+
 	A7105_Regs = (uint8_t*) AFHDS2A_A7105_regs;
 
 	for (uint8_t i = 0; i < 0x32; i++) {
@@ -323,30 +326,34 @@ void A7105_Init(void)
 		if (val != 0xFF)
 			A7105_WriteReg(i, val);
 	}
-/*****************************************************************************/
-	while (A7105_ReadReg(A7105_10_PLL_II) != 0x9E) {
-	}
-/*********************************Calibration************************************/
+
+	while (A7105_ReadReg(A7105_10_PLL_II) != 0x9E);
+
+  // Calibration
 	A7105_Strobe(A7105_PLL);
+
 	//IF Filter Bank Calibration
 	A7105_WriteReg(A7105_02_CALC, 1);
-	while (A7105_ReadReg(A7105_02_CALC)) {
-	}			// Wait for calibration to end
+	while (A7105_ReadReg(A7105_02_CALC));       // Wait for calibration to end
 	//VCO Current Calibration
-	A7105_WriteReg(A7105_24_VCO_CURCAL, 0x13);//Recommended calibration from A7105 Datasheet
+	A7105_WriteReg(A7105_24_VCO_CURCAL, 0x13);  //Recommended calibration from A7105 Datasheet
 	//VCO Bank Calibration
 	A7105_WriteReg(A7105_26_VCO_SBCAL_II, 0x3b);//Recommended calibration from A7105 Datasheet
+
 	//VCO Bank Calibrate channel 0
 	A7105_WriteReg(A7105_0F_CHANNEL, 0);
 	A7105_WriteReg(A7105_02_CALC, 2);
-	while (A7105_ReadReg(A7105_02_CALC)) {
-	}	// Wait for calibration to end
+	while (A7105_ReadReg(A7105_02_CALC));       // Wait for calibration to end
+
+    //VCO Bank Calibrate channel A0
 	A7105_WriteReg(A7105_0F_CHANNEL, 0xa0);
 	A7105_WriteReg(A7105_02_CALC, 2);
-	while (A7105_ReadReg(A7105_02_CALC)) {
-	}	// Wait for calibration to end
+	while (A7105_ReadReg(A7105_02_CALC));       // Wait for calibration to end
+
 	A7105_WriteReg(A7105_25_VCO_SBCAL_I, 0x0A);	//Reset VCO Band calibration
+
 	A7105_SetTxRxMode(TX_EN);
 	A7105_SetPower();
+
 	A7105_Strobe(A7105_STANDBY);
 }

--- a/radio/src/targets/flysky/A7105_SPI.cpp
+++ b/radio/src/targets/flysky/A7105_SPI.cpp
@@ -20,10 +20,15 @@
 #include "stdint.h"
 #include "iface_a7105.h"
 #include "hal.h"
+
+#define NOP() __asm__ __volatile__("nop")
+
 volatile uint8_t RadioState;
 
-uint8_t protocol_flags=0,protocol_flags2=0;
+uint8_t protocol_flags=0;
 uint8_t prev_power=0xFD; // unused power value
+
+uint8_t a7105_spi_error_flag = 0;
 
 // reuse telemetryRxBuffer for native AFHDS2A support
 uint8_t *packet = &telemetryRxBuffer[0];
@@ -47,37 +52,115 @@ const uint8_t AFHDS2A_A7105_regs[] = {
       0x01, 0x0f // 30 - 31
 };
 
-void SPI_RADIO_SendBlock(uint8_t *BufferPtr, uint16_t Size) {
-  __IO uint8_t *spidr = ((__IO uint8_t *)&SPI1->DR);
-  while (Size) {
-    while ((SPI1->SR & SPI_SR_TXE) == 0) {
-    }
-    *spidr = *BufferPtr++;
-    Size--;
-  }
-  while ((SPI1->SR & SPI_SR_BSY) != 0) {
-  }
+void SPI_Write(uint8_t command)
+{//working OK	
+	// while((SPI1->SR & SPI_SR_BSY));
+	*(__IO uint8_t *)&SPI1->DR = command;					//Write the first data item to be transmitted into the SPI_DR register (this clears the TXE flag).
+	// #ifdef DEBUG_SPI
+	// 	debug("%02X ",command);
+	// #endif
+	while (!(SPI1->SR & SPI_SR_RXNE));
+	command = (uint8_t)SPI1->DR;					// ... and read the last received data.
 }
+
+// uint8_t SPI_SDI_Read()
+// {	
+// 	uint8_t rx=0;
+// 	// cli();	//Fix Hubsan droputs??
+// 	while(!(SPI1->SR & SPI_SR_TXE));
+// 	while((SPI1->SR & SPI_SR_BSY));	
+// 	//	
+// 	SPI_DISABLE();
+// 	SPI_SET_BIDIRECTIONAL();
+// 	volatile uint8_t x = SPI1->DR;
+// 	(void)x;
+// 	SPI_ENABLE();
+// 	//
+// 	SPI_DISABLE();				  
+// 	while(!(SPI1->SR& SPI_SR_RXNE));
+// 	rx=(uint8_t)SPI1->DR;
+// 	SPI_SET_UNIDIRECTIONAL();
+// 	SPI_ENABLE();
+// 	// sei();//fix Hubsan dropouts??
+// 	return rx;
+// }
+
+uint8_t SPI_SDI_Read() 
+{
+	uint8_t rx=0;
+	// uint8_t dummy;
+    // while ((SPI1->SR & SPI_SR_FRLVL) != 0) { // not present in multi
+    //   dummy = (uint8_t)(READ_REG(SPI1->DR));
+    // }
+    // (void)dummy;
+	// cli();	//Fix Hubsan droputs??
+	while(!(SPI1->SR & SPI_SR_TXE));
+	while((SPI1->SR & SPI_SR_BSY));
+	// SPI_DISABLE();
+// 	SPI_SET_BIDIRECTIONAL();
+// 	volatile uint8_t x = SPI1->DR;
+// 	(void)x;
+	// SPI_ENABLE();
+	//
+	// SPI_DISABLE();
+    *(__IO uint8_t *)&SPI1->DR = 0x00; // not present in multi
+    while(!(SPI1->SR & SPI_SR_RXNE));
+    rx=(uint8_t)SPI1->DR;
+// 	SPI_SET_UNIDIRECTIONAL();
+	// SPI_ENABLE();
+// 	// sei();//fix Hubsan dropouts??
+	return rx;
+}
+
+// void SPI_RADIO_SendBlock(uint8_t *BufferPtr, uint16_t Size) {
+//   while (Size) {
+//     while ((SPI1->SR & SPI_SR_TXE) == 0);
+// //    while ((SPI1->SR & SPI_SR_BSY) != 0);
+//     *(__IO uint8_t *)&SPI1->DR = *BufferPtr++;
+//     Size--;
+//   }
+//   while (SPI1->SR & (SPI_SR_FTLVL | SPI_SR_BSY));
+// }
 /*---------------------------------------------------------------------------*/
-void SPI_RADIO_ReceiveBlock(uint8_t *BufferPtr, uint16_t Size) {
-  __IO uint8_t *spidr = ((__IO uint8_t *)&SPI1->DR);
-  uint8_t dummy;
-  while ((SPI1->SR & SPI_SR_FRLVL) != 0) {
-    dummy = (uint8_t)(READ_REG(SPI1->DR));
-  }
-  (void)dummy;
-  while (Size) {
-    while ((SPI1->SR & SPI_SR_TXE) == 0) {
-    }
-    *spidr = 0x00;
-    while ((SPI1->SR & SPI_SR_RXNE) == 0) {
-    }
-    *BufferPtr++ = (uint8_t)(READ_REG(SPI1->DR));
-    Size--;
-  }
-  while ((SPI1->SR & SPI_SR_BSY) != 0) {
-  }
+// void SPI_RADIO_ReceiveBlock(uint8_t *BufferPtr, uint16_t Size) {
+//   uint8_t dummy;
+//   while (Size) {
+//     while ((SPI1->SR & SPI_SR_FRLVL) != 0) {
+//       dummy = (uint8_t)(READ_REG(SPI1->DR));
+//     }
+//     (void)dummy;
+//     while ((SPI1->SR & SPI_SR_TXE) == 0);
+//     while ((SPI1->SR & SPI_SR_BSY) != 0);
+//     *(__IO uint8_t *)&SPI1->DR = 0x00;
+//     while ((SPI1->SR & SPI_SR_RXNE) == 0);
+
+//     *BufferPtr++ = (uint8_t)(READ_REG(SPI1->DR));
+//     Size--;
+//   }
+// //   while ((SPI1->SR & SPI_SR_BSY) != 0);
+// }
+
+void SPI_ENABLE()
+{
+	SPI1->CR1 |= SPI_CR1_SPE;
 }
+
+void SPI_DISABLE()
+{
+	SPI1->CR1 &= ~SPI_CR1_SPE;
+}
+
+void SPI_SET_BIDIRECTIONAL()
+{
+	SPI1->CR1 |= SPI_CR1_BIDIMODE;
+	SPI1->CR1  &= ~ SPI_CR1_BIDIOE;//receive only
+}
+
+void SPI_SET_UNIDIRECTIONAL()
+{
+	SPI1->CR1 &= ~SPI_CR1_BIDIMODE;
+}
+
 /*---------------------------------------------------------------------------*/
 inline void a7105_csn_on(void) {RF_SCN_GPIO_PORT->BSRR = RF_SCN_SET_PIN;}
 inline void a7105_csn_off(void) {RF_SCN_GPIO_PORT->BSRR = RF_SCN_RESET_PIN;}
@@ -123,111 +206,78 @@ void A7105_SetTxRxMode(uint8_t mode) {
 }
 
 void A7105_Strobe(uint8_t address) {
-  A7105_CSN_OFF;
-  SPI_RADIO_SendBlock(&address, 1);
-  A7105_CSN_ON;
-}
-
-void A7105_WriteReg(uint8_t address, uint8_t data) {
-  uint8_t out[2];
-  out[0] = address;
-  out[1] = data;
-  A7105_CSN_OFF;
-  SPI_RADIO_SendBlock(out, 2);
-  A7105_CSN_ON;
+  A7105_CSN_off;
+  SPI_Write(address);
+  A7105_CSN_on;
 }
 
 void A7105_WriteData(uint8_t len, uint8_t channel) {
-  uint8_t i;
-  uint8_t out[AFHDS2A_TXPACKET_SIZE + 1];
-  A7105_Strobe(A7105_STANDBY);
-  A7105_Strobe(A7105_RST_WRPTR);
-
-  A7105_CSN_OFF;
-  out[0] = A7105_05_FIFO_DATA;
-  for (i = 0; i < len; i++)
-    out[i + 1] = packet[i];
-  SPI_RADIO_SendBlock(out, len + 1);
-  A7105_CSN_ON;
-  A7105_SetTxRxMode(TX_EN); //Switch to PA
-  A7105_WriteReg(A7105_0F_PLL_I, channel);
-  A7105_Strobe(A7105_TX);
+	uint8_t i;
+	A7105_CSN_off;
+	SPI_Write(A7105_RST_WRPTR);
+	SPI_Write(A7105_05_FIFO_DATA);
+	for (i = 0; i < len; i++)
+		SPI_Write(packet[i]);
+	A7105_CSN_on;
+	// if(protocol!=PROTO_WFLY2)
+	// {
+		// if(!(protocol==PROTO_FLYSKY || (protocol==PROTO_KYOSHO && sub_protocol==KYOSHO_HYPE)))
+		// {
+			A7105_Strobe(A7105_STANDBY);	//Force standby mode, ie cancel any TX or RX...
+			A7105_SetTxRxMode(TX_EN);		//Switch to PA
+		// }
+		A7105_WriteReg(A7105_0F_PLL_I, channel);
+		A7105_Strobe(A7105_TX);
+	// }
 }
 
 void A7105_ReadData(uint8_t len) {
-  uint8_t out;
-  A7105_Strobe(A7105_RST_RDPTR);
-  A7105_CSN_OFF;
-  out = 0x40 | A7105_05_FIFO_DATA;
-  SPI_RADIO_SendBlock(&out, 1);
-  //for (i = 0; i < len; i++) {
-  //  SPI_RADIO_ReceiveBlock(&packet[i], 1);
-  //}
-  SPI_RADIO_ReceiveBlock(packet, len);
+	uint8_t i;
+	A7105_Strobe(A7105_RST_RDPTR);
+	A7105_CSN_off;
+	SPI_Write(0x40 | A7105_05_FIFO_DATA);	//bit 6 =1 for reading
+	for (i=0;i<len;i++)
+		packet[i]=SPI_SDI_Read();
+	A7105_CSN_on;
+}
 
-  A7105_CSN_ON;
+void A7105_WriteReg(uint8_t address, uint8_t data) {
+	A7105_CSN_off;
+	SPI_Write(address); 
+	NOP();
+	SPI_Write(data);  
+	A7105_CSN_on;
 }
 
 uint8_t A7105_ReadReg(uint8_t address) {
-  uint8_t out;
-  uint8_t in;
-  A7105_CSN_OFF;
-  out = address | 0x40;
-  SPI_RADIO_SendBlock(&out, 1);
-  SPI_RADIO_ReceiveBlock(&in, 1);
-  A7105_CSN_ON;
-  return in;
+	uint8_t result;
+	A7105_CSN_off;
+	SPI_Write(address |=0x40);				//bit 6 =1 for reading
+	result = SPI_SDI_Read();  
+	A7105_CSN_on;
+	return(result); 
 }
 
 uint8_t A7105_Reset() {
-  uint8_t result;
-  A7105_WriteReg(A7105_00_MODE, 0x00);
-//  mDelay(1);
-  A7105_SetTxRxMode(TXRX_OFF);                     //Set both GPIO as output and low
-  result = A7105_ReadReg(A7105_10_PLL_II) == 0x9E; //check if is reset.
-  A7105_Strobe(A7105_STANDBY);
-  return result;
+	uint8_t result;
+	
+	A7105_WriteReg(A7105_00_MODE, 0x00);
+	// delay_ms(1);
+	A7105_SetTxRxMode(TXRX_OFF);			             //Set both GPIO as output and low
+	result=A7105_ReadReg(A7105_10_PLL_II) == 0x9E; //check if is reset.
+	A7105_Strobe(A7105_STANDBY);
+	return result;
 }
 
 void A7105_WriteID(uint32_t ida) {
-	uint8_t out[5];
-	A7105_CSN_OFF;
-	out[0] = A7105_06_ID_DATA;
-	out[1] = (ida >> 24) & 0xff;
-	out[2] = (ida >> 16) & 0xff;
-	out[3] = (ida >> 8) & 0xff;
-	out[4] = (ida >> 0) & 0xff;
-	SPI_RADIO_SendBlock(out, 5);
-	A7105_CSN_ON;
+	A7105_CSN_off;
+	SPI_Write(A7105_06_ID_DATA);			//ex id=0x5475c52a ;txid3txid2txid1txid0
+	SPI_Write((ida>>24)&0xff);				//54 
+	SPI_Write((ida>>16)&0xff);				//75
+	SPI_Write((ida>>8)&0xff);				//c5
+	SPI_Write((ida>>0)&0xff);				//2a
+	A7105_CSN_on;
 }
-
-/*
-static void A7105_SetPower_Value(int power)
-{
-	//Power amp is ~+16dBm so:
-	//TXPOWER_100uW  = -23dBm == PAC=0 TBG=0
-	//TXPOWER_300uW  = -20dBm == PAC=0 TBG=1
-	//TXPOWER_1mW    = -16dBm == PAC=0 TBG=2
-	//TXPOWER_3mW    = -11dBm == PAC=0 TBG=4
-	//TXPOWER_10mW   = -6dBm  == PAC=1 TBG=5
-	//TXPOWER_30mW   = 0dBm   == PAC=2 TBG=7
-	//TXPOWER_100mW  = 1dBm   == PAC=3 TBG=7
-	//TXPOWER_150mW  = 1dBm   == PAC=3 TBG=7
-	uint8_t pac, tbg;
-	switch(power) {
-		case 0: pac = 0; tbg = 0; break;
-		case 1: pac = 0; tbg = 1; break;
-		case 2: pac = 0; tbg = 2; break;
-		case 3: pac = 0; tbg = 4; break;
-		case 4: pac = 1; tbg = 5; break;
-		case 5: pac = 2; tbg = 7; break;
-		case 6: pac = 3; tbg = 7; break;
-		case 7: pac = 3; tbg = 7; break;
-		default: pac = 0; tbg = 0; break;
-	};
-	A7105_WriteReg(0x28, (pac << 3) | tbg);
-}
-*/
 
 void A7105_SetPower()
 {
@@ -252,9 +302,8 @@ void A7105_SetPower()
 // this is required for some A7105 modules and/or RXs with inaccurate crystal oscillator
 void A7105_AdjustLOBaseFreq(void)
 {
-	static int16_t old_offset=300;
-	// no tuning for now
-	int16_t offset = old_offset; // g_model.FreqOffset;
+	static int16_t old_offset=2048;
+	int16_t offset = 0; // g_model.FreqOffset; -300 <-> 300
 	if(old_offset==offset)	// offset is the same as before...
 			return;
 	old_offset=offset;
@@ -345,8 +394,6 @@ void A7105_Sleep(void) {
 	A7105_WriteReg(A7105_0C_GPIO2_PIN_II, 0x33);
 }
 
-#define ID_NORMAL 0x55201041
-#define ID_PLUS   0xAA201041
 void A7105_Init(void)
 {
 	uint8_t *A7105_Regs = 0;

--- a/radio/src/targets/flysky/AFHDS2A_a7105.cpp
+++ b/radio/src/targets/flysky/AFHDS2A_a7105.cpp
@@ -345,18 +345,20 @@ EndSendData_:  //-----------------------------------------------------------
   SETBIT(RadioState, SEND_RES, RES);
   return;
 ResData_:  //-----------------------------------------------------------
-  A7105_ReadData(AFHDS2A_RXPACKET_SIZE);
-  if (packet[0] == 0xAA && packet[9] == 0xFC)  // RX is asking for settings
-    packet_type = AFHDS2A_PACKET_SETTINGS;
-  if (packet[0] == 0xAA && packet[9] == 0xFD)  // RX is asking for FailSafe
-    packet_type = AFHDS2A_PACKET_FAILSAFE;
-  if (packet[0] == 0xAA || packet[0] == 0xAC) {
-    if (!memcmp(&packet[1], ID.rx_tx_addr, 4) // Validate TX address
-       /* && !memcmp(&packet[5], &g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]], 4)*/) {  // Validate RX address
-      AFHDS2A_update_telemetry();
+  if (!(A7105_ReadReg(A7105_00_MODE) & (1<<5))) { // CRCF Ok
+    A7105_ReadData(AFHDS2A_RXPACKET_SIZE);
+    if (packet[0] == 0xAA && packet[9] == 0xFC)  // RX is asking for settings
+        packet_type = AFHDS2A_PACKET_SETTINGS;
+    else if (packet[0] == 0xAA && packet[9] == 0xFD)  // RX is asking for FailSafe
+        packet_type = AFHDS2A_PACKET_FAILSAFE;
+    else if (packet[0] == 0xAA || packet[0] == 0xAC) {
+        if (!memcmp(&packet[1], ID.rx_tx_addr, 4) // Validate TX address
+        /* && !memcmp(&packet[5], &g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]], 4)*/) {  // Validate RX address
+        AFHDS2A_update_telemetry();
+        }
     }
+    SETBIT(RadioState, SEND_RES, SEND);
   }
-  SETBIT(RadioState, SEND_RES, SEND);
   return;
 Send_:  //---------------------------------------------------------------
   A7105_AntSwitch();

--- a/radio/src/targets/flysky/AFHDS2A_a7105.cpp
+++ b/radio/src/targets/flysky/AFHDS2A_a7105.cpp
@@ -315,12 +315,14 @@ EndSendBIND123_:  //-----------------------------------------------------------
   SETBIT(RadioState, SEND_RES, RES);
   return;
 ResBIND123_:  //-----------------------------------------------------------
-  A7105_ReadData(AFHDS2A_RXPACKET_SIZE);
-  if ((packet[0] == 0xbc) & (packet[9] == 0x01)) {
-    memcpy(&g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]], &packet[5], 4);
-    RadioState = (RadioState & 0xF0) | AFHDS2A_BIND4;
-    bind_phase = 0;
-    SETBIT(RadioState, SEND_RES, SEND);
+  if (!(A7105_ReadReg(A7105_00_MODE) & (1<<5))) { // CRCF Ok
+    A7105_ReadData(AFHDS2A_RXPACKET_SIZE);
+    if ((packet[0] == 0xbc) & (packet[9] == 0x01)) {
+        memcpy(&g_eeGeneral.receiverId[g_model.header.modelId[INTERNAL_MODULE]], &packet[5], 4);
+        RadioState = (RadioState & 0xF0) | AFHDS2A_BIND4;
+        bind_phase = 0;
+        SETBIT(RadioState, SEND_RES, SEND);
+    }
   }
   return;
 SendData_:  //--------------------------------------------------------------

--- a/radio/src/targets/flysky/board.h
+++ b/radio/src/targets/flysky/board.h
@@ -107,8 +107,6 @@ extern "C" {
 
 extern uint16_t sessionTimer;
 
-extern volatile uint8_t a7105_spi_error_flag;
-
 // Board driver
 void boardInit(void);
 void boardOff(void);

--- a/radio/src/targets/flysky/board.h
+++ b/radio/src/targets/flysky/board.h
@@ -107,6 +107,8 @@ extern "C" {
 
 extern uint16_t sessionTimer;
 
+extern volatile uint8_t a7105_spi_error_flag;
+
 // Board driver
 void boardInit(void);
 void boardOff(void);

--- a/radio/src/targets/flysky/hal.h
+++ b/radio/src/targets/flysky/hal.h
@@ -185,12 +185,6 @@ void TIM16_IRQHandler(void);
 #define RF_RF1_SET_PIN GPIO_BSRR_BS_11
 #define RF_RF1_RESET_PIN GPIO_BSRR_BR_11
 
-void SPI_ENABLE(void);
-void SPI_DISABLE(void);
-void SPI_SET_BIDIRECTIONAL(void);
-void SPI_SET_UNIDIRECTIONAL(void);
-// void SPI_RADIO_SendBlock(uint8_t *BufferPtr, uint16_t Size);
-// void SPI_RADIO_ReceiveBlock(uint8_t *BufferPtr, uint16_t Size);
 void SPI_Write(uint8_t command);
 uint8_t SPI_SDI_Read(void);
 void a7105_csn_on(void); 

--- a/radio/src/targets/flysky/hal.h
+++ b/radio/src/targets/flysky/hal.h
@@ -185,8 +185,14 @@ void TIM16_IRQHandler(void);
 #define RF_RF1_SET_PIN GPIO_BSRR_BS_11
 #define RF_RF1_RESET_PIN GPIO_BSRR_BR_11
 
-void SPI_RADIO_SendBlock(uint8_t *BufferPtr, uint16_t Size);
-void SPI_RADIO_ReceiveBlock(uint8_t *BufferPtr, uint16_t Size);
+void SPI_ENABLE(void);
+void SPI_DISABLE(void);
+void SPI_SET_BIDIRECTIONAL(void);
+void SPI_SET_UNIDIRECTIONAL(void);
+// void SPI_RADIO_SendBlock(uint8_t *BufferPtr, uint16_t Size);
+// void SPI_RADIO_ReceiveBlock(uint8_t *BufferPtr, uint16_t Size);
+void SPI_Write(uint8_t command);
+uint8_t SPI_SDI_Read(void);
 void a7105_csn_on(void); 
 void a7105_csn_off(void);
 void RF0_SetVal(void);
@@ -200,8 +206,8 @@ void initAFHDS2A();
 void ActionAFHDS2A();
 void init_afhds2a(uint32_t port);
 void disable_afhds2a(uint32_t port);
-#define A7105_CSN_ON a7105_csn_on()  
-#define A7105_CSN_OFF a7105_csn_off()
+#define A7105_CSN_on a7105_csn_on()  
+#define A7105_CSN_off a7105_csn_off()
 
 /******************************************************************************/
 /*                                                                            */
@@ -365,6 +371,7 @@ void disable_afhds2a(uint32_t port);
   #define INTMODULE_DMA_FLAG_TC         DMA_IT_TCIF5
   #define INTMODULE_TIMER_FREQ          (PERI2_FREQUENCY * TIMER_MULT_APB2)
 */
+#define INTMODULE_RCC_APB2Periph      (RCC_APB2Periph_TIM16 | RCC_APB2Periph_SPI1)
 
 // External Module
 #define EXTMODULE_PWR_GPIO            GPIOC
@@ -552,7 +559,7 @@ F072 IRQs
 #define TIMER_2MHz_TIMER                TIM7
 
 // Mixer scheduler timer
-#define MIXER_SCHEDULER_TIMER_RCC_APB1Periph RCC_APB2Periph_TIM17
+#define MIXER_SCHEDULER_TIMER_RCC_APB2Periph RCC_APB2Periph_TIM17
 #define MIXER_SCHEDULER_TIMER                TIM17
 #define MIXER_SCHEDULER_TIMER_FREQ           (PERI1_FREQUENCY * TIMER_MULT_APB1)
 #define MIXER_SCHEDULER_TIMER_IRQn           TIM17_IRQn
@@ -561,6 +568,6 @@ F072 IRQs
 //all used RCC goes here
 #define RCC_AHB1_LIST                   (I2C_RCC_AHB1Periph | BACKLIGHT_RCC_AHB1Periph | LCD_RCC_AHB1Periph | KEYS_RCC_AHB1Periph | BUZZER_RCC_AHBPeriph | EXTMODULE_RCC_AHBPeriph | CRC_RCC_AHB1Periph | TELEMETRY_RCC_AHB1Periph | AUX_SERIAL_RCC_AHB1Periph)
 #define RCC_APB1_LIST                   (I2C_RCC_APB1Periph | INTERRUPT_xMS_RCC_APB1Periph | TIMER_2MHz_RCC_APB1Periph | TELEMETRY_RCC_APB1Periph | BACKLIGHT_RCC_APB1Periph | RCC_APB1Periph_USB)
-#define RCC_APB2_LIST                   (MIXER_SCHEDULER_TIMER_RCC_APB1Periph | PWM_RCC_APB2Periph | EXTMODULE_RCC_APB2Periph | AUX_SERIAL_RCC_APB2Periph)
+#define RCC_APB2_LIST                   (MIXER_SCHEDULER_TIMER_RCC_APB2Periph | PWM_RCC_APB2Periph | INTMODULE_RCC_APB2Periph | EXTMODULE_RCC_APB2Periph | AUX_SERIAL_RCC_APB2Periph)
 
 #endif // _HAL_H_

--- a/radio/src/targets/flysky/iface_a7105.h
+++ b/radio/src/targets/flysky/iface_a7105.h
@@ -69,7 +69,7 @@ enum A7105_POWER
 //#define	CH15	14
 //#define	CH16	15
 
-extern uint8_t protocol_flags,protocol_flags2;
+extern uint8_t protocol_flags;
 extern uint8_t protocol;
 extern uint8_t prev_power; // unused power value
 

--- a/radio/src/targets/flysky/intmodule_pulses_driver.cpp
+++ b/radio/src/targets/flysky/intmodule_pulses_driver.cpp
@@ -62,21 +62,21 @@ void intmoduleNoneStart() {
 
 void initSPI1()
 {
-	SPI_DISABLE(); // SPI_2.end();
+	SPI1->CR1 &= ~SPI_CR1_SPE; // SPI_DISABLE(); // SPI_2.end();
 
 	// SPI1->CR1 &= ~SPI_CR1_DFF_8_BIT;		//8 bits format, this bit should be written only when SPI is disabled (SPE = ?0?) for correct operation.
-
 	// SPI1->CR1 &= ~SPI_CR1_LSBFIRST;		// Set the SPI_1 bit order MSB first
 	// SPI1->CR1 &= ~(SPI_CR1_CPOL|SPI_CR1_CPHA);	// Set the SPI_1 data mode 0: Clock idles low, data captured on rising edge (first transition)
 	// SPI1->CR1 &= ~(SPI_CR1_BR);
-	// // SPI1->CR1 |= SPI_CR1_BR_PCLK_DIV_8;	// Set the speed (36 / 8 = 4.5 MHz SPI_1 speed) SPI_CR1_BR_PCLK_DIV_8
 	// SPI1->CR1 |= SPI_CR1_BR_1;	/*!< BaudRate control equal to fPCLK/8   */
 	// SPI1->CR1 = (SPI_CR1_BIDIMODE | SPI_CR1_BIDIOE); 
   SPI1->CR1 |= ((SPI_CR1_MSTR | SPI_CR1_SSI) | SPI_CR1_SSM | SPI_CR1_BR_1);	/*!< BaudRate control equal to fPCLK/8   */
 
   SPI1->CR2 |= (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0 | SPI_CR2_FRXTH); // Data length: 8-bit + FIFO reception threshold 1/4 (8-bit)
 
-  SPI_ENABLE(); //SPI_2.begin();								//Initialize the SPI_1 port.
+//  CLEAR_BIT(SPI1->CR2, SPI_CR2_NSSP); /* Disable NSS pulse management */
+
+  SPI1->CR1 |= SPI_CR1_SPE; // SPI_ENABLE(); //SPI_2.begin();								//Initialize the SPI_1 port.
 }
 
 void intmoduleAfhds2aStart() {
@@ -93,26 +93,6 @@ void intmoduleAfhds2aStart() {
   // GPIOE->PUPDR |= 0x00000000U;               // PULL_NO
   GPIOE->MODER |= (GPIO_MODER_MODER13_1 | GPIO_MODER_MODER14_1 | GPIO_MODER_MODER15_1);      // Select alternate function mode
   GPIOE->AFR[1] |= ((0x0000001U << (5 * 4)) | (0x0000001U << (6 * 4)) | (0x0000001U << (7 * 4)));  // Select alternate function 1
-
-  //  SPI1->CR1 = (SPI_CR1_BIDIMODE | SPI_CR1_BIDIOE);          /*!< Half-Duplex Tx mode. Tx transfer on 1 line */
-  // SPI1->CR1 |= (SPI_CR1_MSTR | SPI_CR1_SSI); /*!< Master configuration  */
-  // SPI1->CR1 |= 0x00000000U;                  /*!< SPI_POLARITY_LOW */
-  // SPI1->CR1 |= 0x00000000U;                  /*!< First clock transition is the first data capture edge  */
-  // SPI1->CR1 |= SPI_CR1_SSM;                  /*!< NSS managed internally. NSS pin not used and free */
-  // SPI1->CR1 |= SPI_CR1_BR_1;                 /*!< BaudRate control equal to fPCLK/8   */
-  // SPI1->CR1 |= 0x00000000U;                  /*!< Data is transmitted/received with the MSB first */
-  // SPI1->CR1 |= 0x00000000U;                  /*!< CRC calculation disabled */
-  // tmpreg = (SPI_CR1_MSTR | SPI_CR1_SSI) | SPI_CR1_SSM | SPI_CR1_BR_1 | SPI_CR1_BR_2;
-  // SPI1->CR1 = tmpreg;
-
-  // SPI1->CR2 |= (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0); /*!< Data length for SPI transfer:  8 bits */
-  // SPI1->CR2 |= 0x00000000U;                                  /*!< Motorola mode. Used as default value */
-  // SPI1->CR2 |= SPI_CR2_FRXTH; // FIFO reception threshold 1/4 (one byte)
-  // tmpreg = (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0) | SPI_CR2_FRXTH;
-  // SPI1->CR2 |= tmpreg;
-
-  // CLEAR_BIT(SPI1->CR2, SPI_CR2_NSSP); /* Disable NSS pulse management */
-  // SET_BIT(SPI1->CR1, SPI_CR1_SPE);    // SPI_ENABLE
 
   initSPI1();
 

--- a/radio/src/targets/flysky/intmodule_pulses_driver.cpp
+++ b/radio/src/targets/flysky/intmodule_pulses_driver.cpp
@@ -62,8 +62,7 @@ void intmoduleNoneStart() {
 
 void initSPI1()
 {
-	SPI_DISABLE();
-	// SPI_2.end();
+	SPI_DISABLE(); // SPI_2.end();
 
 	// SPI1->CR1 &= ~SPI_CR1_DFF_8_BIT;		//8 bits format, this bit should be written only when SPI is disabled (SPE = ?0?) for correct operation.
 
@@ -75,7 +74,7 @@ void initSPI1()
 	// SPI1->CR1 = (SPI_CR1_BIDIMODE | SPI_CR1_BIDIOE); 
   SPI1->CR1 |= ((SPI_CR1_MSTR | SPI_CR1_SSI) | SPI_CR1_SSM | SPI_CR1_BR_1);	/*!< BaudRate control equal to fPCLK/8   */
 
-  SPI1->CR2 |= (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0 | SPI_CR2_FRXTH); // Data length for SPI transfer:  8 bits + FIFO reception threshold 1/4 (one byte)
+  SPI1->CR2 |= (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0 | SPI_CR2_FRXTH /* | SPI_CR2_ERRIE*/); // Data length: 8-bit + FIFO reception threshold 1/4 (8-bit)
 
   SPI_ENABLE(); //SPI_2.begin();								//Initialize the SPI_1 port.
 }

--- a/radio/src/targets/flysky/intmodule_pulses_driver.cpp
+++ b/radio/src/targets/flysky/intmodule_pulses_driver.cpp
@@ -74,7 +74,7 @@ void initSPI1()
 	// SPI1->CR1 = (SPI_CR1_BIDIMODE | SPI_CR1_BIDIOE); 
   SPI1->CR1 |= ((SPI_CR1_MSTR | SPI_CR1_SSI) | SPI_CR1_SSM | SPI_CR1_BR_1);	/*!< BaudRate control equal to fPCLK/8   */
 
-  SPI1->CR2 |= (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0 | SPI_CR2_FRXTH /* | SPI_CR2_ERRIE*/); // Data length: 8-bit + FIFO reception threshold 1/4 (8-bit)
+  SPI1->CR2 |= (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0 | SPI_CR2_FRXTH); // Data length: 8-bit + FIFO reception threshold 1/4 (8-bit)
 
   SPI_ENABLE(); //SPI_2.begin();								//Initialize the SPI_1 port.
 }

--- a/radio/src/targets/flysky/intmodule_pulses_driver.cpp
+++ b/radio/src/targets/flysky/intmodule_pulses_driver.cpp
@@ -40,76 +40,82 @@ void intmoduleStop() {
   }
 }
 
-void intmoduleNoneStart() {
-  TRACE("intmoduleNoneStart");
-    __IO uint32_t tmpreg;
-  SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN);
-
-  /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN);
+void initIntModuleTimer(uint16_t periodUs) {
   CLEAR_BIT(TIM16->CR1, TIM_CR1_ARPE);   // Disable ARR Preload
   CLEAR_BIT(TIM16->SMCR, TIM_SMCR_MSM);  // Disable Master Slave Mode
   WRITE_REG(TIM16->PSC, 2);              // Prescaler
-  WRITE_REG(TIM16->ARR, 61759);          // Preload
+  WRITE_REG(TIM16->ARR, 65535 - periodUs); // Preload, was: 61759 => 3776
 
   /* TIM16 interrupt Init */
-  SET_BIT(TIM16->DIER, TIM_DIER_UIE);  // Enable update interrupt (UIE)
+  SET_BIT(TIM16->DIER, TIM_DIER_UIE);    // Enable update interrupt (UIE)
   NVIC_SetPriority(TIM16_IRQn, 2);
   NVIC_EnableIRQ(TIM16_IRQn);
+}
 
-  (void)tmpreg;
+void intmoduleNoneStart() {
+  TRACE("intmoduleNoneStart");
+  initIntModuleTimer(50000); // 50 ms
   ahfds2aEnabled = false;
 
   EnablePRTTim();
+}
+
+void initSPI1()
+{
+	SPI_DISABLE();
+	// SPI_2.end();
+
+	// SPI1->CR1 &= ~SPI_CR1_DFF_8_BIT;		//8 bits format, this bit should be written only when SPI is disabled (SPE = ?0?) for correct operation.
+
+	// SPI1->CR1 &= ~SPI_CR1_LSBFIRST;		// Set the SPI_1 bit order MSB first
+	// SPI1->CR1 &= ~(SPI_CR1_CPOL|SPI_CR1_CPHA);	// Set the SPI_1 data mode 0: Clock idles low, data captured on rising edge (first transition)
+	// SPI1->CR1 &= ~(SPI_CR1_BR);
+	// // SPI1->CR1 |= SPI_CR1_BR_PCLK_DIV_8;	// Set the speed (36 / 8 = 4.5 MHz SPI_1 speed) SPI_CR1_BR_PCLK_DIV_8
+	// SPI1->CR1 |= SPI_CR1_BR_1;	/*!< BaudRate control equal to fPCLK/8   */
+	// SPI1->CR1 = (SPI_CR1_BIDIMODE | SPI_CR1_BIDIOE); 
+  SPI1->CR1 |= ((SPI_CR1_MSTR | SPI_CR1_SSI) | SPI_CR1_SSM | SPI_CR1_BR_1);	/*!< BaudRate control equal to fPCLK/8   */
+
+  SPI1->CR2 |= (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0 | SPI_CR2_FRXTH); // Data length for SPI transfer:  8 bits + FIFO reception threshold 1/4 (one byte)
+
+  SPI_ENABLE(); //SPI_2.begin();								//Initialize the SPI_1 port.
 }
 
 void intmoduleAfhds2aStart() {
   TRACE("intmoduleAfhds2aStart");
   // RF
   __IO uint32_t tmpreg;
-  /* SPI1 clock enable */
-  SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN);
-  /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN);
   /**SPI1 GPIO Configuration
   PE13   ------> SPI1_SCK
   PE14   ------> SPI1_MISO
   PE15   ------> SPI1_MOSI
   */
-  //PE13
-  GPIOE->OSPEEDR |= GPIO_OSPEEDR_OSPEEDR13;  // high output speed
-  GPIOE->OTYPER |= 0x00000000U;              // Output PUSHPULL
-  GPIOE->PUPDR |= 0x00000000U;               // PULL_NO
-  GPIOE->MODER |= GPIO_MODER_MODER13_1;      // Select alternate function mode
-  GPIOE->AFR[1] |= (0x0000001U << (5 * 4));  // Select alternate function 1
-  //PE14
-  GPIOE->OSPEEDR |= GPIO_OSPEEDR_OSPEEDR14;  // high output speed
-  GPIOE->OTYPER |= 0x00000000U;              // Output PUSHPULL
-  GPIOE->PUPDR |= 0x00000000U;               // PULL_NO
-  GPIOE->MODER |= GPIO_MODER_MODER14_1;      // Select alternate function mode
-  GPIOE->AFR[1] |= (0x0000001U << (6 * 4));  // Select alternate function 1
-  //PE15
-  GPIOE->OSPEEDR |= GPIO_OSPEEDR_OSPEEDR15;  // high output speed
-  GPIOE->OTYPER |= 0x00000000U;              // Output PUSHPULL
-  GPIOE->PUPDR |= 0x00000000U;               //GPIO_PUPDR_PUPDR15_0;//                  // PULL_NO
-  GPIOE->MODER |= GPIO_MODER_MODER15_1;      // Select alternate function mode
-  GPIOE->AFR[1] |= (0x0000001U << (7 * 4));  // Select alternate function 1
+  GPIOE->OSPEEDR |= (GPIO_OSPEEDR_OSPEEDR13 | GPIO_OSPEEDR_OSPEEDR14 | GPIO_OSPEEDR_OSPEEDR15);  // high output speed
+  // GPIOE->OTYPER |= 0x00000000U;              // Output PUSHPULL
+  // GPIOE->PUPDR |= 0x00000000U;               // PULL_NO
+  GPIOE->MODER |= (GPIO_MODER_MODER13_1 | GPIO_MODER_MODER14_1 | GPIO_MODER_MODER15_1);      // Select alternate function mode
+  GPIOE->AFR[1] |= ((0x0000001U << (5 * 4)) | (0x0000001U << (6 * 4)) | (0x0000001U << (7 * 4)));  // Select alternate function 1
 
   //  SPI1->CR1 = (SPI_CR1_BIDIMODE | SPI_CR1_BIDIOE);          /*!< Half-Duplex Tx mode. Tx transfer on 1 line */
-  SPI1->CR1 |= (SPI_CR1_MSTR | SPI_CR1_SSI); /*!< Master configuration  */
-  SPI1->CR1 |= 0x00000000U;                  /*!< SPI_POLARITY_LOW */
-  SPI1->CR1 |= 0x00000000U;                  /*!< First clock transition is the first data capture edge  */
-  SPI1->CR1 |= SPI_CR1_SSM;                  /*!< NSS managed internally. NSS pin not used and free */
-  SPI1->CR1 |= SPI_CR1_BR_1;                 /*!< BaudRate control equal to fPCLK/8   */
-  SPI1->CR1 |= 0x00000000U;                  /*!< Data is transmitted/received with the MSB first */
-  SPI1->CR1 |= 0x00000000U;                  /*!< CRC calculation disabled */
+  // SPI1->CR1 |= (SPI_CR1_MSTR | SPI_CR1_SSI); /*!< Master configuration  */
+  // SPI1->CR1 |= 0x00000000U;                  /*!< SPI_POLARITY_LOW */
+  // SPI1->CR1 |= 0x00000000U;                  /*!< First clock transition is the first data capture edge  */
+  // SPI1->CR1 |= SPI_CR1_SSM;                  /*!< NSS managed internally. NSS pin not used and free */
+  // SPI1->CR1 |= SPI_CR1_BR_1;                 /*!< BaudRate control equal to fPCLK/8   */
+  // SPI1->CR1 |= 0x00000000U;                  /*!< Data is transmitted/received with the MSB first */
+  // SPI1->CR1 |= 0x00000000U;                  /*!< CRC calculation disabled */
+  // tmpreg = (SPI_CR1_MSTR | SPI_CR1_SSI) | SPI_CR1_SSM | SPI_CR1_BR_1 | SPI_CR1_BR_2;
+  // SPI1->CR1 = tmpreg;
 
-  SPI1->CR2 |= (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0); /*!< Data length for SPI transfer:  8 bits */
-  SPI1->CR2 |= 0x00000000U;                                  /*!< Motorola mode. Used as default value */
-  SPI1->CR2 |= SPI_CR2_FRXTH;
+  // SPI1->CR2 |= (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0); /*!< Data length for SPI transfer:  8 bits */
+  // SPI1->CR2 |= 0x00000000U;                                  /*!< Motorola mode. Used as default value */
+  // SPI1->CR2 |= SPI_CR2_FRXTH; // FIFO reception threshold 1/4 (one byte)
+  // tmpreg = (SPI_CR2_DS_2 | SPI_CR2_DS_1 | SPI_CR2_DS_0) | SPI_CR2_FRXTH;
+  // SPI1->CR2 |= tmpreg;
 
-  CLEAR_BIT(SPI1->CR2, SPI_CR2_NSSP); /* Disable NSS pulse management */
-  SET_BIT(SPI1->CR1, SPI_CR1_SPE);    // SPI_ENABLE
+  // CLEAR_BIT(SPI1->CR2, SPI_CR2_NSSP); /* Disable NSS pulse management */
+  // SET_BIT(SPI1->CR1, SPI_CR1_SPE);    // SPI_ENABLE
+
+  initSPI1();
 
   //RF_SCN output
   RF_SCN_GPIO_PORT->MODER |= GPIO_MODER_MODER12_0;
@@ -130,23 +136,9 @@ void intmoduleAfhds2aStart() {
 
   NVIC_SetPriority(EXTI2_3_IRQn, 2);
   NVIC_EnableIRQ(EXTI2_3_IRQn);
-  /*------------------Radio_Protocol_Timer_Init(3860 uS TIM16)------------------*/
-  /* TIM16 clock enable */
-  SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN);
 
-  /* Delay after an RCC peripheral clock enabling */
-  tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM16EN);
-  CLEAR_BIT(TIM16->CR1, TIM_CR1_ARPE);   // Disable ARR Preload
-  CLEAR_BIT(TIM16->SMCR, TIM_SMCR_MSM);  // Disable Master Slave Mode
-  WRITE_REG(TIM16->PSC, 2);              // Prescaler
-  WRITE_REG(TIM16->ARR, 61759);          // Preload
-
-  /* TIM16 interrupt Init */
-  SET_BIT(TIM16->DIER, TIM_DIER_UIE);  // Enable update interrupt (UIE)
-  NVIC_SetPriority(TIM16_IRQn, 2);
-  NVIC_EnableIRQ(TIM16_IRQn);
-
-  (void)tmpreg;
+  /*------------------Radio_Protocol_Timer_Init(3850 uS TIM16)------------------*/
+  initIntModuleTimer(3850); // was: 3776 us
   ahfds2aEnabled = true;
   initAFHDS2A();
   EnablePRTTim();

--- a/radio/src/telemetry/flysky_ibus.cpp
+++ b/radio/src/telemetry/flysky_ibus.cpp
@@ -228,10 +228,7 @@ void processFlySkySensor(const uint8_t *packet, uint8_t type) {
     return;
   }
 
-  // skip unknown, but report AFHDS2A_ID_S8* sensors
-  if (id >= AFHDS2A_ID_S84 && id <= AFHDS2A_ID_S8a) {
-    setTelemetryValue(TELEM_PROTO_FLYSKY_IBUS, id, 0, instance, value, UNIT_RAW, 0);
-  }
+  setTelemetryValue(TELEM_PROTO_FLYSKY_IBUS, id, 0, instance, value, UNIT_RAW, 0);
 }
 
 void processFlySkyPacket(const uint8_t *packet) {


### PR DESCRIPTION
This solves random data and unknown sensors to show up occasionally.

- Added CRCF check for received packets.
- Removed unknown sensors guard because this fixes it.
- Adjusted A7105 SPI interface to match Multiprotocol module.
- Adjusted timing to match Multiprotocol module.