### PR TITLE
Delay for FSgimbal throttle check

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -876,6 +876,9 @@ void checkAll() {
 
   // we don't check the throttle stick if the radio is not calibrated
   if (g_eeGeneral.chkSum == evalChkSum())
+#if defined(FLYSKY_GIMBAL) // delay necessary for the throttle check to successfully detect when serial flysky gimbal throttle is not at zero
+    RTOS_WAIT_MS(23);
+#endif    
     checkThrottleStick();
 
   checkSwitches();


### PR DESCRIPTION
The initial serial connection between the radio and the FSgimbal is not fast enough for the current implementation of the throttle check.

A delay of 23 ms is needed before firing the throttle check in opentx.cpp

This has been successfully tested and working fine.