### PR TITLE
Make all switches 3pos

### DIFF
--- a/radio/src/targets/flysky/CMakeLists.txt
+++ b/radio/src/targets/flysky/CMakeLists.txt
@@ -5,6 +5,7 @@ option(PCBI6X_INAV "Enable INAV Lite telemetry screen" NO) # ~2kB
 option(PCBI6X_USB_VBUS "Remove manual USB connection, just auto using VBUS, requires wiring USB VBUS to PA15 pad" NO)
 option(AFHDS2A_LQI_CH "Send RSSI at channel 1-17" 17)
 option(DFPLAYER "Enables DFPlayer on AUX3 TX" NO) # ~1.7kB
+option(ALL3POS "Makes all switches 3pos" NO)
 
 if(PCB STREQUAL I6X)
   set(PWR_BUTTON "SWITCH" CACHE STRING "Pwr button type (PRESS/SWITCH)")
@@ -34,6 +35,10 @@ if(PCB STREQUAL I6X)
   add_definitions(-DEEPROM_VARIANT=0)
   add_definitions(-DSOFTWARE_VOLUME)
   add_definitions(-DAFHDS2A)
+endif()
+
+if (ALL3POS)
+  add_definitions(-DALL3POS)
 endif()
 
 if(NOT AFHDS2A_LQI_CH)

--- a/radio/src/targets/flysky/board.h
+++ b/radio/src/targets/flysky/board.h
@@ -291,7 +291,11 @@ enum EnumSwitchesPositions
   SW_SD1,
   SW_SD2,
 };
+#ifdef ALL3POS
+#define IS_3POS(x)            (((x) == SW_SA) || ((x) == SW_SC) || ((x) == SW_SC) || ((x) == SW_SC))
+#else
 #define IS_3POS(x)            ((x) == SW_SC)
+#endif
 #define IS_TOGGLE(x)					false
 #define NUM_SWITCHES          4
 


### PR DESCRIPTION
This PR adds the compile time option ALL3POS. 

Settings this option makes all switches SA, SB, SC, SD to 3pos switches (normally only SC is 3pos). 

Clearly, one has to physically change the 2pos switches SA, SB and SD to 3pos as well ;-) 