### PR TITLE
Add CRSF Full duplex mode

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -51,6 +51,7 @@ option(NIGHTLY_BUILD_WARNING "Warn this is a nightly build" OFF)
 option(MODULE_R9M_FLEX_FW "Add R9M options for non certified firmwwares" OFF)
 option(CRSF_UNINVERTED "Enable uninverted CRSF" OFF)
 option(EXTPWR_INVERT "Enable inverted pwr enable on PC13" OFF)
+option(CRSF_FULLDUPLEX "Enable Crossfire full duplex mode on PA15 as RX" OFF)
 
 # since we reset all default CMAKE compiler flags for firmware builds, provide an alternate way for user to specify additional flags.
 set(FIRMWARE_C_FLAGS "" CACHE STRING "Additional flags for firmware target c compiler (note: all CMAKE_C_FLAGS[_*] are ignored for firmware/bootloader).")
@@ -342,6 +343,10 @@ endif()
 
 if(EXTPWR_INVERT)
   add_definitions(-DEXTPWR_INVERT)
+endif()
+
+if(CRSF_FULLDUPLEX)
+  add_definitions(-DCRSF_FULLDUPLEX)
 endif()
 
 set(SRC

--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -49,7 +49,6 @@ option(FRSKY_STICKS "Reverse sticks for FrSky sticks" OFF)
 option(NANO "Use nano newlib and binalloc")
 option(NIGHTLY_BUILD_WARNING "Warn this is a nightly build" OFF)
 option(MODULE_R9M_FLEX_FW "Add R9M options for non certified firmwwares" OFF)
-option(CRSF_UNINVERTED "Enable uninverted CRSF" OFF)
 option(EXTPWR_INVERT "Enable inverted pwr enable on PC13" OFF)
 option(CRSF_FULLDUPLEX "Enable Crossfire full duplex mode on PA15 as RX" OFF)
 
@@ -335,10 +334,6 @@ endif(NIGHTLY_BUILD_WARNING)
 
 if(MODULE_R9M_FLEX_FW)
   add_definitions(-DMODULE_R9M_FLEX_FW)
-endif()
-
-if(CRSF_UNINVERTED)
-  add_definitions(-DCRSF_UNINVERTED)
 endif()
 
 if(EXTPWR_INVERT)

--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -50,7 +50,7 @@ option(NANO "Use nano newlib and binalloc")
 option(NIGHTLY_BUILD_WARNING "Warn this is a nightly build" OFF)
 option(MODULE_R9M_FLEX_FW "Add R9M options for non certified firmwwares" OFF)
 option(EXTPWR_INVERT "Enable inverted pwr enable on PC13" OFF)
-option(CRSF_FULLDUPLEX "Enable Crossfire full duplex mode on PA15 as RX" OFF)
+option(CRSF_FULLDUPLEX "Enable CRSF full duplex mode with RX on PA15" OFF)
 
 # since we reset all default CMAKE compiler flags for firmware builds, provide an alternate way for user to specify additional flags.
 set(FIRMWARE_C_FLAGS "" CACHE STRING "Additional flags for firmware target c compiler (note: all CMAKE_C_FLAGS[_*] are ignored for firmware/bootloader).")

--- a/radio/src/targets/flysky/hal.h
+++ b/radio/src/targets/flysky/hal.h
@@ -353,8 +353,8 @@ extern void ISR_TIMER3_CAPT_vect(void);
 #define TELEMETRY_RX_GPIO_PIN           GPIO_Pin_15 // PA.15
 #define TELEMETRY_GPIO_PinSource_TX     GPIO_PinSource5
 #define TELEMETRY_GPIO_PinSource_RX     GPIO_PinSource15
-#define TELEMETRY_GPIO_TX_AF            GPIO_AF_0
-#define TELEMETRY_GPIO_RX_AF            GPIO_AF_1
+#define TELEMETRY_TX_GPIO_AF            GPIO_AF_0
+#define TELEMETRY_RX_GPIO_AF            GPIO_AF_1
 #define TELEMETRY_USART                 USART2
 #define TELEMETRY_DMA_Channel_TX        DMA1_Channel4
 #define TELEMETRY_DMA_TX_IRQn           DMA1_Channel4_5_IRQn

--- a/radio/src/targets/flysky/hal.h
+++ b/radio/src/targets/flysky/hal.h
@@ -345,13 +345,14 @@ extern void ISR_TIMER3_CAPT_vect(void);
 #define SPORT_MAX_BAUDRATE            400000
 
 // Telemetry
-#define TELEMETRY_RCC_AHB1Periph        (RCC_AHBPeriph_GPIOD | RCC_AHBPeriph_DMA1)
+#define TELEMETRY_RCC_AHB1Periph        (RCC_AHBPeriph_GPIOD | RCC_AHBPeriph_GPIOA | RCC_AHBPeriph_DMA1)
 #define TELEMETRY_RCC_APB1Periph        RCC_APB1Periph_USART2
 #define TELEMETRY_GPIO                  GPIOD
 #define TELEMETRY_TX_GPIO_PIN           GPIO_Pin_5  // PD.05
-#define TELEMETRY_RX_GPIO_PIN           
+#define TELEMETRY_RX_GPIO               GPIOA
+#define TELEMETRY_RX_GPIO_PIN           GPIO_Pin_15 // PA.15
 #define TELEMETRY_GPIO_PinSource_TX     GPIO_PinSource5
-#define TELEMETRY_GPIO_PinSource_RX     
+#define TELEMETRY_GPIO_PinSource_RX     GPIO_PinSource15
 #define TELEMETRY_GPIO_AF               GPIO_AF_0
 #define TELEMETRY_USART                 USART2
 #define TELEMETRY_DMA_Channel_TX        DMA1_Channel4

--- a/radio/src/targets/flysky/hal.h
+++ b/radio/src/targets/flysky/hal.h
@@ -353,7 +353,8 @@ extern void ISR_TIMER3_CAPT_vect(void);
 #define TELEMETRY_RX_GPIO_PIN           GPIO_Pin_15 // PA.15
 #define TELEMETRY_GPIO_PinSource_TX     GPIO_PinSource5
 #define TELEMETRY_GPIO_PinSource_RX     GPIO_PinSource15
-#define TELEMETRY_GPIO_AF               GPIO_AF_0
+#define TELEMETRY_GPIO_TX_AF            GPIO_AF_0
+#define TELEMETRY_GPIO_RX_AF            GPIO_AF_1
 #define TELEMETRY_USART                 USART2
 #define TELEMETRY_DMA_Channel_TX        DMA1_Channel4
 #define TELEMETRY_DMA_TX_IRQn           DMA1_Channel4_5_IRQn

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -173,9 +173,7 @@ extern "C" void TELEMETRY_DMA_TX_IRQHandler(void) {
     DMA_ClearITPendingBit(TELEMETRY_DMA_TX_FLAG_TC);
     // clear TC flag before enabling interrupt
     TELEMETRY_USART->ISR &= ~USART_ISR_TC;
-#if !defined(CRSF_FULLDUPLEX)
     TELEMETRY_USART->CR1 |= USART_CR1_TCIE;
-#endif
   }
 }
 

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -56,10 +56,10 @@ void telemetryPortInit(uint32_t baudrate, uint8_t mode) {
 
 #if defined(CRSF_FULLDUPLEX)
   GPIO_InitStructure.GPIO_Pin = TELEMETRY_RX_GPIO_PIN;
-  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
-  GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
-  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
-  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
+  // GPIO_InitStructure.GPIO_Mode = GPIO_Mode_AF;
+  // GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+  // GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+  // GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
   GPIO_Init(TELEMETRY_RX_GPIO, &GPIO_InitStructure);
   GPIO_PinAFConfig(TELEMETRY_RX_GPIO, TELEMETRY_GPIO_PinSource_RX, TELEMETRY_GPIO_AF);
 #endif

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -108,11 +108,9 @@ void telemetryPortInit(uint32_t baudrate, uint8_t mode) {
                                 | DMA_MemoryDataSize_Byte;
 
 #if defined(CRSF_FULLDUPLEX)
-  // Full duplex mode
   TELEMETRY_USART->CR3 |= USART_DMAReq_Rx;
 #else
-  // Half duplex mode
-  TELEMETRY_USART->CR3 |= USART_CR3_HDSEL | USART_DMAReq_Rx;
+  TELEMETRY_USART->CR3 |= USART_CR3_HDSEL /*Half duplex*/ | USART_DMAReq_Rx;
 #endif
 
   USART_Cmd(TELEMETRY_USART, ENABLE);
@@ -120,18 +118,15 @@ void telemetryPortInit(uint32_t baudrate, uint8_t mode) {
 }
 
 void telemetryPortSetDirectionOutput() {
-#if !defined(CRSF_FULLDUPLEX)
   // Disable RX
   TELEMETRY_DMA_Channel_RX->CCR &= ~DMA_CCR_EN;
   TELEMETRY_USART->CR1 &= ~USART_CR1_RE;
-#endif
 
   // Enable TX
   TELEMETRY_USART->CR1 |= USART_CR1_TE;
 }
 
 void telemetryPortSetDirectionInput() {
-#if !defined(CRSF_FULLDUPLEX)
   // Disable TX
   TELEMETRY_DMA_Channel_TX->CCR &= ~DMA_CCR_EN;
   TELEMETRY_USART->CR1 &= ~USART_CR1_TE;
@@ -139,7 +134,6 @@ void telemetryPortSetDirectionInput() {
   // Enable RX
   TELEMETRY_USART->CR1 |= USART_CR1_RE;
   TELEMETRY_DMA_Channel_RX->CCR |= DMA_CCR_EN;
-#endif
 }
 
 void sportSendBuffer(const uint8_t* buffer, unsigned long count) {
@@ -191,11 +185,11 @@ extern "C" void TELEMETRY_USART_IRQHandler(void) {
     TELEMETRY_USART->CR1 &= ~USART_CR1_TCIE;
 #if !defined(CRSF_FULLDUPLEX)
     telemetryPortSetDirectionInput();
+#endif
     while (status & (USART_FLAG_RXNE)) {
       status = TELEMETRY_USART->RDR;
       status = TELEMETRY_USART->ISR;
     }
-#endif
   }
 
   // RX, handled by DMA

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -141,7 +141,6 @@ void telemetryPortSetDirectionInput() {
 }
 
 void sportSendBuffer(const uint8_t* buffer, unsigned long count) {
-
   telemetryPortSetDirectionOutput();
 
   DMA_DeInit(TELEMETRY_DMA_Channel_TX);

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -130,8 +130,10 @@ void telemetryPortSetDirectionOutput() {
 
 void telemetryPortSetDirectionInput() {
   // Disable TX
+#if !defined(CRSF_FULLDUPLEX)
   TELEMETRY_DMA_Channel_TX->CCR &= ~DMA_CCR_EN;
   TELEMETRY_USART->CR1 &= ~USART_CR1_TE;
+#endif
 
   // Enable RX
   TELEMETRY_USART->CR1 |= USART_CR1_RE;
@@ -184,9 +186,7 @@ extern "C" void TELEMETRY_USART_IRQHandler(void) {
   // TX, transfer complete
   if ((status & USART_ISR_TC) && (TELEMETRY_USART->CR1 & USART_CR1_TCIE)) {
     TELEMETRY_USART->CR1 &= ~USART_CR1_TCIE;
-#if !defined(CRSF_FULLDUPLEX)
     telemetryPortSetDirectionInput();
-#endif
     while (status & (USART_FLAG_RXNE)) {
       status = TELEMETRY_USART->RDR;
       status = TELEMETRY_USART->ISR;

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -61,7 +61,7 @@ void telemetryPortInit(uint32_t baudrate, uint8_t mode) {
   // GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
   // GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
   GPIO_Init(TELEMETRY_RX_GPIO, &GPIO_InitStructure);
-  GPIO_PinAFConfig(TELEMETRY_RX_GPIO, TELEMETRY_GPIO_PinSource_RX, TELEMETRY_GPIO_RX_AF);
+  GPIO_PinAFConfig(TELEMETRY_RX_GPIO, TELEMETRY_GPIO_PinSource_RX, TELEMETRY_RX_GPIO_AF);
 #endif
 
   USART_DeInit(TELEMETRY_USART);
@@ -69,7 +69,7 @@ void telemetryPortInit(uint32_t baudrate, uint8_t mode) {
   // OverSampling + IDLE
   TELEMETRY_USART->CR1 |= ( USART_CR1_OVER8 | USART_CR1_IDLEIE );
 
-  GPIO_PinAFConfig(TELEMETRY_GPIO, TELEMETRY_GPIO_PinSource_TX, TELEMETRY_GPIO_TX_AF);
+  GPIO_PinAFConfig(TELEMETRY_GPIO, TELEMETRY_GPIO_PinSource_TX, TELEMETRY_TX_GPIO_AF);
 
   USART_InitStructure.USART_BaudRate = baudrate;
   USART_InitStructure.USART_WordLength = USART_WordLength_8b;

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -119,8 +119,10 @@ void telemetryPortInit(uint32_t baudrate, uint8_t mode) {
 
 void telemetryPortSetDirectionOutput() {
   // Disable RX
+#if !defined(CRSF_FULLDUPLEX)
   TELEMETRY_DMA_Channel_RX->CCR &= ~DMA_CCR_EN;
   TELEMETRY_USART->CR1 &= ~USART_CR1_RE;
+#endif
 
   // Enable TX
   TELEMETRY_USART->CR1 |= USART_CR1_TE;
@@ -137,9 +139,8 @@ void telemetryPortSetDirectionInput() {
 }
 
 void sportSendBuffer(const uint8_t* buffer, unsigned long count) {
-#if !defined(CRSF_FULLDUPLEX)
+
   telemetryPortSetDirectionOutput();
-#endif
 
   DMA_DeInit(TELEMETRY_DMA_Channel_TX);
 

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -61,7 +61,7 @@ void telemetryPortInit(uint32_t baudrate, uint8_t mode) {
   // GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
   // GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
   GPIO_Init(TELEMETRY_RX_GPIO, &GPIO_InitStructure);
-  GPIO_PinAFConfig(TELEMETRY_RX_GPIO, TELEMETRY_GPIO_PinSource_RX, TELEMETRY_GPIO_AF);
+  GPIO_PinAFConfig(TELEMETRY_RX_GPIO, TELEMETRY_GPIO_PinSource_RX, TELEMETRY_GPIO_RX_AF);
 #endif
 
   USART_DeInit(TELEMETRY_USART);
@@ -69,7 +69,7 @@ void telemetryPortInit(uint32_t baudrate, uint8_t mode) {
   // OverSampling + IDLE
   TELEMETRY_USART->CR1 |= ( USART_CR1_OVER8 | USART_CR1_IDLEIE );
 
-  GPIO_PinAFConfig(TELEMETRY_GPIO, TELEMETRY_GPIO_PinSource_TX, TELEMETRY_GPIO_AF);
+  GPIO_PinAFConfig(TELEMETRY_GPIO, TELEMETRY_GPIO_PinSource_TX, TELEMETRY_GPIO_TX_AF);
 
   USART_InitStructure.USART_BaudRate = baudrate;
   USART_InitStructure.USART_WordLength = USART_WordLength_8b;


### PR DESCRIPTION
Adds CRSF RX on `PA15` pcd pad.
New build time option: `CRSF_FULLDUPLEX`, set to `YES` for testing.

Makes `CRSF_UNINVERTED` obsolete.