### PR TITLE
AFHDS2A Fixes

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -769,22 +769,15 @@ void menuModelSetup(event_t event)
 #if defined(PCBI6X) 
       case ITEM_MODEL_INTERNAL_MODULE_MODE:
         lcdDrawTextAlignedLeft(y, INDENT TR_MODE);
-        lcdDrawTextAtIndex(
-          MODEL_SETUP_2ND_COLUMN, 
-          y, 
-          STR_I6X_PROTOCOLS, 
-          1+g_model.moduleData[INTERNAL_MODULE].rfProtocol, 
-          attr);
+        lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_I6X_PROTOCOLS, 1+g_model.moduleData[INTERNAL_MODULE].rfProtocol, attr);
         if (attr) {
           g_model.moduleData[INTERNAL_MODULE].rfProtocol = 
-          checkIncDec(event, 
-                      g_model.moduleData[INTERNAL_MODULE].rfProtocol, 
-                      RF_I6X_PROTO_OFF, 
-                      RF_I6X_PROTO_LAST, 
-                      EE_MODEL, 
-                      isRfProtocolAvailable);
+          checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].rfProtocol, RF_I6X_PROTO_OFF, RF_I6X_PROTO_LAST, EE_MODEL, isRfProtocolAvailable);
           if (checkIncDec_Ret) { // modified?
             g_model.moduleData[INTERNAL_MODULE].type = MODULE_TYPE_AFHDS2A_SPI;
+            g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
+            g_model.moduleData[INTERNAL_MODULE].channelsCount = MAX_OUTPUT_CHANNELS - 8; // 16
+            g_model.moduleData[INTERNAL_MODULE].afhds2a.servoFreq = 50;
             if (g_model.moduleData[INTERNAL_MODULE].rfProtocol == RF_PROTO_OFF){
               g_model.moduleData[INTERNAL_MODULE].type = MODULE_TYPE_NONE;
             }
@@ -1442,16 +1435,16 @@ void menuModelSetup(event_t event)
 
 #if defined(AFHDS2A)
   if (IS_RANGECHECK_ENABLE()) {
-    showMessageBox("RQly ");
-    lcdDrawNumber(16+4*FW, 5*FH, TELEMETRY_RSSI(), BOLD);
+    showMessageBox("RQly");
+    lcdDrawNumber(WARNING_LINE_X, 5*FH, TELEMETRY_RSSI(), BOLD);
   }
 #endif
 
   // some field just finished being edited
   if (old_editMode > 0 && s_editMode == 0) {
     switch(menuVerticalPosition) {
-#if defined(PCBTARANIS) || defined(PCBI6X)
-    case ITEM_MODEL_INTERNAL_MODULE_BIND:
+#if defined(PCBTARANIS) /*|| defined(PCBI6X)*/ // disabled to save space
+    case ITEM_MODEL_INTERNAL_MODULE_BIND + 1: // for some reason index was off by one
       if (menuHorizontalPosition == 0)
         checkModelIdUnique(g_eeGeneral.currModel, INTERNAL_MODULE);
       break;

--- a/radio/src/gui/128x64/radio_hardware.cpp
+++ b/radio/src/gui/128x64/radio_hardware.cpp
@@ -284,7 +284,7 @@ void menuRadioHardware(event_t event)
         }
         break;
 #endif // MENU_DIAG_ANAS_KEYS
-#if !defined(PCBI6X)
+#if defined(SDCARD)
       case ITEM_RADIO_BACKUP_EEPROM:
         lcdDrawTextAlignedLeft(y, BUTTON(STR_EEBACKUP), attr);
         if (attr && event == EVT_KEY_FIRST(KEY_ENTER)) {
@@ -292,7 +292,7 @@ void menuRadioHardware(event_t event)
           eepromBackup();
         }
         break;
-#endif // PCBI6X
+#endif
       case ITEM_RADIO_FACTORY_RESET:
         onFactoryResetConfirm(warningResult);
         if (LCD_W < 212)

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -150,8 +150,10 @@ const mm_protocol_definition *getMultiProtocolDefinition (uint8_t protocol);
 #define MULTIMODULE_OPTIONS_ROW         HIDDEN_ROW
 #endif
 
+#define MAX_RXNUM                      63
+
 #if defined(PCBI6X)
-#define MAX_RX_NUM(x)                  (isModuleA7105(x) ? 15 : 63)
+#define MAX_RX_NUM(x)                  (isModuleA7105(x) ? 15 : MAX_RXNUM)
 #else
 #define MAX_RX_NUM(x)                  (isModuleDSM2(x) ? 20 : isModuleMultimodule(x) ? MULTI_MAX_RX_NUM(x) : 63)
 #endif

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -401,36 +401,29 @@ void checkModelIdUnique(uint8_t index, uint8_t module) {
   }
 }
 
-uint8_t findNextUnusedModelId(uint8_t index, uint8_t module) {
-  // assume 63 is the highest Model ID
-  // and use 64 bits
-  uint8_t usedModelIds[8];
+uint8_t findNextUnusedModelId(uint8_t index, uint8_t module)
+{
+  uint8_t usedModelIds[(MAX_RXNUM + 7) / 8];
   memset(usedModelIds, 0, sizeof(usedModelIds));
 
-  for (uint8_t mod_i = 0; mod_i < MAX_MODELS; mod_i++) {
-    if (mod_i == index)
+  for (uint8_t modelIndex = 0; modelIndex < MAX_MODELS; modelIndex++) {
+    if (modelIndex == index)
       continue;
 
-    uint8_t id = modelHeaders[mod_i].modelId[module];
+    uint8_t id = modelHeaders[modelIndex].modelId[module];
     if (id == 0)
       continue;
 
-    uint8_t mask = 1;
-    for (uint32_t i = 1; i < (id & 7); i++)
-      mask <<= 1;
-
-    usedModelIds[id >> 3] |= mask;
+    uint8_t mask = 1u << (id & 7u);
+    usedModelIds[id >> 3u] |= mask;
   }
 
-  uint8_t new_id = 1;
-  uint8_t tst_mask = 1;
-  for (; new_id < MAX_RX_NUM(module); new_id++) {
-    if (!(usedModelIds[new_id >> 3] & tst_mask)) {
+  for (uint8_t id = 1; id <= MAX_RX_NUM(module); id++) {
+    uint8_t mask = 1u << (id & 7u);
+    if (!(usedModelIds[id >> 3u] & mask)) {
       // found free ID
-      return new_id;
+      return id;
     }
-    if ((tst_mask <<= 1) == 0)
-      tst_mask = 1;
   }
 
   // failed finding something...
@@ -443,7 +436,7 @@ void modelDefault(uint8_t id) {
 
   applyDefaultTemplate();
 
-#if defined(LUA) && defined(PCBTARANIS)  //Horus uses menuModelWizard() for wizard
+#if defined(LUA) && defined(PCBTARANIS)  // Horus uses menuModelWizard() for wizard
   if (isFileAvailable(WIZARD_PATH "/" WIZARD_NAME)) {
     f_chdir(WIZARD_PATH);
     luaExec(WIZARD_NAME);
@@ -454,28 +447,26 @@ void modelDefault(uint8_t id) {
   g_model.moduleData[INTERNAL_MODULE].type = MODULE_TYPE_XJT;
   g_model.moduleData[INTERNAL_MODULE].channelsCount = defaultModuleChannels_M8(INTERNAL_MODULE);
 #elif defined(PCBI6X)
-  g_model.moduleData[INTERNAL_MODULE].type = MODULE_TYPE_AFHDS2A_SPI;
-  g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
-  g_model.moduleData[INTERNAL_MODULE].channelsCount = MAX_OUTPUT_CHANNELS;
-  g_model.moduleData[INTERNAL_MODULE].subType = AFHDS2A_SUBTYPE_PWM_IBUS;
-  g_model.moduleData[INTERNAL_MODULE].afhds2a.servoFreq = 50;
+ g_model.moduleData[INTERNAL_MODULE].rfProtocol = RF_I6X_PROTO_OFF;
+//  g_model.moduleData[INTERNAL_MODULE].type = MODULE_TYPE_AFHDS2A_SPI;
+//  g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
+//  g_model.moduleData[INTERNAL_MODULE].channelsCount = MAX_OUTPUT_CHANNELS - 8;
+//  g_model.moduleData[INTERNAL_MODULE].subType = AFHDS2A_SUBTYPE_PWM_IBUS;
+//  g_model.moduleData[INTERNAL_MODULE].afhds2a.servoFreq = 50;
+//  #if defined(EEPROM)
+//    g_model.header.modelId[INTERNAL_MODULE] = findNextUnusedModelId(id, INTERNAL_MODULE);
+//    modelHeaders[id].modelId[INTERNAL_MODULE] = g_model.header.modelId[INTERNAL_MODULE];
+//  #endif
 #endif
 
 #if defined(PCBXLITE)
   g_model.trainerMode = TRAINER_MODE_MASTER_BLUETOOTH;
 #endif
 
-#if defined(EEPROM)
-  for (int i = 0; i < NUM_MODULES; i++) {
-    modelHeaders[id].modelId[i] = g_model.header.modelId[i] = id + 1;
-  }
-  checkModelIdUnique(id, 0);
-#endif
-
 #if defined(FLIGHT_MODES) && defined(GVARS)
-  for (int p = 1; p < MAX_FLIGHT_MODES; p++) {
-    for (int i = 0; i < MAX_GVARS; i++) {
-      g_model.flightModeData[p].gvars[i] = GVAR_MAX + 1;
+  for (int fmIdx = 1; fmIdx < MAX_FLIGHT_MODES; fmIdx++) {
+    for (int gvarIdx = 0; gvarIdx < MAX_GVARS; gvarIdx++) {
+      g_model.flightModeData[fmIdx].gvars[gvarIdx] = GVAR_MAX + 1;
     }
   }
 #endif


### PR DESCRIPTION
- fixed failsafe channels setup missing channels > 8,
- fixed check on invalid line and disabled checkModelIdUnique, 
- default model internal module to off,
- refactored findNextUnusedModelId (opentx#7259)