### PR TITLE
Fixed issue where returning from popup was blocking UP/DOWN navigation,

### DIFF
--- a/radio/src/gui/128x64/gui.h
+++ b/radio/src/gui/128x64/gui.h
@@ -53,18 +53,6 @@ extern uint8_t noHighlightCounter;
 void drawSlider(coord_t x, coord_t y, uint8_t width, uint8_t value, uint8_t max, uint8_t attr);
 void drawSlider(coord_t x, coord_t y, uint8_t value, uint8_t max, uint8_t attr);
 
-#if defined(NAVIGATION_POT1)
-extern int16_t p1valdiff;
-#else
-  #define p1valdiff 0
-#endif
-
-#if defined(NAVIGATION_POT2)
-extern int8_t p2valdiff;
-#else
-  #define p2valdiff 0
-#endif
-
 extern int8_t checkIncDec_Ret;  // global helper vars
 
 #define EDIT_SELECT_MENU               -1

--- a/radio/src/gui/128x64/model_flightmodes.cpp
+++ b/radio/src/gui/128x64/model_flightmodes.cpp
@@ -126,7 +126,7 @@ void menuModelFlightModeOne(event_t event)
         lcdDrawTextAlignedLeft(y, STR_ROTARY_ENCODER);
         for (uint8_t t=0; t<NUM_ROTARY_ENCODERS; t++) {
           putsRotaryEncoderMode(MIXES_2ND_COLUMN+(t*FW), y, s_currIdx, t, menuHorizontalPosition==t ? attr : 0);
-          if (attr && menuHorizontalPosition==t && ((editMode>0) || p1valdiff)) {
+          if (attr && menuHorizontalPosition==t && (editMode > 0)) {
             int16_t v = flightModeAddress(s_currIdx)->rotaryEncoders[t];
             if (v < ROTARY_ENCODER_MAX) v = ROTARY_ENCODER_MAX;
             v = checkIncDec(event, v, ROTARY_ENCODER_MAX, ROTARY_ENCODER_MAX+MAX_FLIGHT_MODES-1, EE_MODEL);
@@ -175,7 +175,7 @@ void menuModelFlightModeOne(event_t event)
         else {
           lcdDrawText(9*FW, y, STR_OWN, posHorz==1 ? attr : 0);
         }
-        if (attr && s_currIdx>0 && posHorz==1 && (editMode>0 || p1valdiff)) {
+        if (attr && s_currIdx>0 && posHorz==1 && editMode > 0) {
           if (v < GVAR_MAX) v = GVAR_MAX;
           v = checkIncDec(event, v, GVAR_MAX, GVAR_MAX+MAX_FLIGHT_MODES-1, EE_MODEL);
           if (checkIncDec_Ret) {

--- a/radio/src/gui/128x64/model_logical_switches.cpp
+++ b/radio/src/gui/128x64/model_logical_switches.cpp
@@ -236,24 +236,18 @@ void onLogicalSwitchesMenu(const char *result)
   }
 #if defined(SDCARD)
   else if (result == STR_COPY) {
-
     clipboard.type = CLIPBOARD_TYPE_CUSTOM_SWITCH;
     clipboard.data.csw = *cs;
-
   }
   else if (result == STR_PASTE) {
-
     *cs = clipboard.data.csw;
     storageDirty(EE_MODEL);
-
   }
-  else 
 #endif
-  if (result == STR_CLEAR) {
+  else if (result == STR_CLEAR) {
     memset(cs, 0, sizeof(LogicalSwitchData));
     storageDirty(EE_MODEL);
   }
-
 }
 
 void menuModelLogicalSwitches(event_t event)
@@ -264,7 +258,7 @@ void menuModelLogicalSwitches(event_t event)
   uint8_t k = 0;
   int8_t sub = menuVerticalPosition - HEADER_LINE;
 
-  if (event==EVT_KEY_FIRST(KEY_ENTER)) {
+  if (event == EVT_KEY_FIRST(KEY_ENTER)) {
     killEvents(event);
     LogicalSwitchData * cs = lswAddress(sub);
     if (cs->func)
@@ -279,7 +273,15 @@ void menuModelLogicalSwitches(event_t event)
 #endif
     if (cs->func || cs->v1 || cs->v2 || cs->delay || cs->duration || cs->andsw)
       POPUP_MENU_ADD_ITEM(STR_CLEAR);
-    POPUP_MENU_START(onLogicalSwitchesMenu);
+    if (popupMenuItemsCount == 1) {
+      popupMenuItemsCount = 0;
+      s_currIdx = sub;
+      pushMenu(menuModelLogicalSwitchOne);
+    }
+    else {
+      s_editMode = 0; // Was set in 'check' function.
+      POPUP_MENU_START(onLogicalSwitchesMenu);
+    }
   }
 
   for (uint32_t i=0; i<LCD_LINES-1; i++) {

--- a/radio/src/gui/128x64/model_outputs.cpp
+++ b/radio/src/gui/128x64/model_outputs.cpp
@@ -104,7 +104,7 @@ void menuModelLimitsOne(event_t event)
     coord_t y = MENU_HEADER_HEIGHT + 1 + k*FH;
     uint8_t i = k + menuVerticalOffset;
     uint8_t attr = (sub==i ? (s_editMode>0 ? BLINK|INVERS : INVERS) : 0);
-    uint8_t active = (attr && (s_editMode>0 || p1valdiff)) ;
+    uint8_t active = (attr && s_editMode > 0) ;
     int limit = (g_model.extendedLimits ? LIMIT_EXT_MAX : 1000);
 
     switch (i) {

--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -86,12 +86,6 @@ void menuModelSelect(event_t event)
 
   check_submenu_simple(_event_, MAX_MODELS - HEADER_LINE);
 
-#if defined(NAVIGATION_POT2)
-  if (event==0 && p2valdiff<0) {
-    event = EVT_KEY_FIRST(KEY_RIGHT);
-  }
-#endif
-
   if (s_editMode > 0) s_editMode = 0;
 
 

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -399,7 +399,7 @@ void menuModelSetup(event_t event)
         drawStringWithIndex(0*FW, y, STR_TIMER, timerIdx+1);
         drawTimerMode(MODEL_SETUP_2ND_COLUMN, y, timer->mode, menuHorizontalPosition==0 ? attr : 0);
         drawTimer(MODEL_SETUP_2ND_COLUMN+5*FW-2+5*FWNUM+1, y, timer->start, RIGHT | (menuHorizontalPosition==1 ? attr : 0), menuHorizontalPosition==2 ? attr : 0);
-        if (attr && (editMode > 0 || p1valdiff)) {
+        if (attr && editMode > 0) {
           div_t qr = div(timer->start, 60);
           switch (menuHorizontalPosition) {
             case 0:
@@ -729,7 +729,7 @@ void menuModelSetup(event_t event)
           lcdDrawTextAtIndex(x, y, STR_RETA123, i, ((menuHorizontalPosition==i) && attr) ? BLINK|INVERS : (((g_model.beepANACenter & ((BeepANACenter)1<<i)) || (attr && CURSOR_ON_LINE())) ? INVERS : 0 ) );
         }
         if (attr && CURSOR_ON_CELL) {
-          if (event==EVT_KEY_BREAK(KEY_ENTER) || p1valdiff) {
+          if (event==EVT_KEY_BREAK(KEY_ENTER)) {
             if (READ_ONLY_UNLOCKED()) {
               s_editMode = 0;
               g_model.beepANACenter ^= ((BeepANACenter)1<<menuHorizontalPosition);
@@ -838,7 +838,7 @@ void menuModelSetup(event_t event)
             lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN+5*FW, y, STR_MULTI_PROTOCOLS, multi_rfProto, menuHorizontalPosition==1 ? attr : 0);
         }
 #endif
-        if (attr && (editMode>0 || p1valdiff)) {
+        if (attr && editMode > 0) {
           switch (menuHorizontalPosition) {
             case 0:
               g_model.moduleData[EXTERNAL_MODULE].type = checkIncDec(
@@ -922,7 +922,7 @@ void menuModelSetup(event_t event)
           if (pdef->subTypeString != nullptr)
             lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, pdef->subTypeString, g_model.moduleData[EXTERNAL_MODULE].subType, attr);
         }
-        if (attr && (editMode > 0 || p1valdiff)) {
+        if (attr && editMode > 0) {
           switch (menuHorizontalPosition) {
             case 0:
               if (multi_rfProto == MM_RF_CUSTOM_SELECTED)
@@ -1038,7 +1038,7 @@ void menuModelSetup(event_t event)
           lcdDrawNumber(lcdLastRightPos, y, moduleData.channelsStart+1, LEFT | (menuHorizontalPosition==0 ? attr : 0));
           lcdDrawChar(lcdLastRightPos, y, '-');
           lcdDrawNumber(lcdLastRightPos + FW+1, y, moduleData.channelsStart+sentModuleChannels(moduleIdx), LEFT | (menuHorizontalPosition==1 ? attr : 0));
-          if (attr && (editMode>0 || p1valdiff)) {
+          if (attr && editMode > 0) {
             switch (menuHorizontalPosition) {
               case 0:
                 CHECK_INCDEC_MODELVAR_ZERO(event, moduleData.channelsStart, 32-8-moduleData.channelsCount);
@@ -1072,7 +1072,7 @@ void menuModelSetup(event_t event)
           lcdDrawChar(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, 'u');
           lcdDrawNumber(MODEL_SETUP_2ND_COLUMN+8*FW+2, y, (moduleData.ppm.delay*50)+300, RIGHT | ((CURSOR_ON_LINE() || menuHorizontalPosition==1) ? attr : 0));
           lcdDrawChar(MODEL_SETUP_2ND_COLUMN+10*FW, y, moduleData.ppm.pulsePol ? '+' : '-', (CURSOR_ON_LINE() || menuHorizontalPosition==2) ? attr : 0);
-          if (attr && (editMode>0 || p1valdiff)) {
+          if (attr && editMode > 0) {
             switch (menuHorizontalPosition) {
               case 0:
                 CHECK_INCDEC_MODELVAR(event, moduleData.ppm.frameLength, -20, 35);
@@ -1118,7 +1118,7 @@ void menuModelSetup(event_t event)
             if (xOffsetBind)
               lcdDrawNumber(MODEL_SETUP_2ND_COLUMN, y, g_model.header.modelId[moduleIdx], (l_posHorz==0 ? attr : 0) | LEADING0|LEFT, 2);
             if (attr && l_posHorz == 0) {
-              if (editMode>0 || p1valdiff) {
+              if (editMode > 0) {
                 CHECK_INCDEC_MODELVAR_ZERO(event, g_model.header.modelId[moduleIdx], MAX_RX_NUM(moduleIdx));
                 if (checkIncDec_Ret) {
                   if (isModuleCrossfire(moduleIdx))
@@ -1236,7 +1236,7 @@ void menuModelSetup(event_t event)
           if (moduleData.failsafeMode != FAILSAFE_CUSTOM)
             menuHorizontalPosition = 0;
           if (menuHorizontalPosition == 0) {
-            if (editMode > 0 || p1valdiff) {
+            if (editMode > 0) {
               CHECK_INCDEC_MODELVAR_ZERO(event, moduleData.failsafeMode, FAILSAFE_LAST);
               if (checkIncDec_Ret) SEND_FAILSAFE_NOW(moduleIdx);
             }

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -111,19 +111,18 @@ void onCustomFunctionsMenu(const char * result)
     eeFlags = EE_GENERAL;
   }
 
+#if defined(SDCARD)
   if (result == STR_COPY) {
-	#if defined(SDCARD)
     clipboard.type = CLIPBOARD_TYPE_CUSTOM_FUNCTION;
     clipboard.data.cfn = *cfn;
-	#endif
   }
   else if (result == STR_PASTE) {
-	#if defined(SDCARD)
     *cfn = clipboard.data.cfn;
     storageDirty(eeFlags);
-	#endif
   }
-  else if (result == STR_CLEAR) {
+  else
+#endif
+  if (result == STR_CLEAR) {
     memset(cfn, 0, sizeof(CustomFunctionData));
     storageDirty(eeFlags);
   }
@@ -160,8 +159,8 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
 #endif
     killEvents(event);
     CustomFunctionData *cfn = &functions[sub];
-    if (!CFN_EMPTY(cfn))
 #if !defined(PCBI6X)
+    if (!CFN_EMPTY(cfn))
       POPUP_MENU_ADD_ITEM(STR_COPY);
     if (clipboard.type == CLIPBOARD_TYPE_CUSTOM_FUNCTION && isAssignableFunctionAvailable(clipboard.data.cfn.func))
       POPUP_MENU_ADD_ITEM(STR_PASTE);
@@ -191,7 +190,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
     uint8_t func = CFN_FUNC(cfn);
     for (uint32_t j=0; j<5; j++) {
       uint8_t attr = ((sub==k && menuHorizontalPosition==j) ? ((s_editMode>0) ? BLINK|INVERS : INVERS) : 0);
-      uint8_t active = (attr && (s_editMode>0 || p1valdiff));
+      uint8_t active = (attr && s_editMode > 0);
       switch (j) {
         case 0:
           if (sub==k && menuHorizontalPosition < 1 && CFN_SWITCH(cfn) == SWSRC_NONE) {

--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -591,7 +591,7 @@ void menuModelTelemetryFrsky(event_t event)
         }
         lcdDrawNumber(TELEM_COL2, y, -10+g_model.frsky.varioMin, ((CURSOR_ON_LINE() || menuHorizontalPosition==0) ? attr : 0)|LEFT);
         lcdDrawNumber(TELEM_COL2+4*FW, y, 10+g_model.frsky.varioMax, ((CURSOR_ON_LINE() || menuHorizontalPosition==1) ? attr : 0)|LEFT);
-        if (attr && (s_editMode>0 || p1valdiff)) {
+        if (attr && s_editMode > 0) {
           switch (menuHorizontalPosition) {
             case 0:
               CHECK_INCDEC_MODELVAR(event, g_model.frsky.varioMin, -7, 7);
@@ -608,7 +608,7 @@ void menuModelTelemetryFrsky(event_t event)
         lcdDrawNumber(TELEM_COL2, y, -5+g_model.frsky.varioCenterMin, ((CURSOR_ON_LINE() || menuHorizontalPosition==0) ? attr : 0)|PREC1|LEFT);
         lcdDrawNumber(TELEM_COL2+4*FW, y, 5+g_model.frsky.varioCenterMax, ((CURSOR_ON_LINE() || menuHorizontalPosition==1) ? attr : 0)|PREC1|LEFT);
         lcdDrawTextAtIndex(TELEM_COL2+8*FW, y, STR_VVARIOCENTER, g_model.frsky.varioCenterSilent, (menuHorizontalPosition==2 ? attr : 0));
-        if (attr && (s_editMode>0 || p1valdiff)) {
+        if (attr && s_editMode > 0) {
           switch (menuHorizontalPosition) {
             case 0:
               CHECK_INCDEC_MODELVAR(event, g_model.frsky.varioCenterMin, -16, 5+min<int8_t>(10, g_model.frsky.varioCenterMax+5));

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -191,12 +191,12 @@ void menuRadioSetup(event_t event)
             case 0:
               lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, t.tm_year+TM_YEAR_BASE, rowattr|RIGHT);
               lcdDrawChar(lcdNextPos, y, '-');
-              if (rowattr && (s_editMode>0 || p1valdiff)) t.tm_year = checkIncDec(event, t.tm_year, 112, 200, 0);
+              if (rowattr && s_editMode > 0) t.tm_year = checkIncDec(event, t.tm_year, 112, 200, 0);
               break;
             case 1:
               lcdDrawNumber(lcdNextPos+3*FW-2, y, t.tm_mon+1, rowattr|LEADING0|RIGHT, 2);
               lcdDrawChar(lcdNextPos, y, '-');
-              if (rowattr && (s_editMode>0 || p1valdiff)) t.tm_mon = checkIncDec(event, t.tm_mon, 0, 11, 0);
+              if (rowattr && s_editMode > 0) t.tm_mon = checkIncDec(event, t.tm_mon, 0, 11, 0);
               break;
             case 2:
             {
@@ -205,7 +205,7 @@ void menuRadioSetup(event_t event)
               static const uint8_t dmon[]  = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
               dlim += dmon[t.tm_mon];
               lcdDrawNumber(lcdNextPos+6*FW-4, y, t.tm_mday, rowattr|LEADING0|RIGHT, 2);
-              if (rowattr && (s_editMode>0 || p1valdiff)) t.tm_mday = checkIncDec(event, t.tm_mday, 1, dlim, 0);
+              if (rowattr && s_editMode > 0) t.tm_mday = checkIncDec(event, t.tm_mday, 1, dlim, 0);
               break;
             }
           }
@@ -223,16 +223,16 @@ void menuRadioSetup(event_t event)
             case 0:
               lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, t.tm_hour, rowattr|LEADING0|RIGHT, 2);
               lcdDrawChar(lcdNextPos + 1, y, ':');
-              if (rowattr && (s_editMode>0 || p1valdiff)) t.tm_hour = checkIncDec(event, t.tm_hour, 0, 23, 0);
+              if (rowattr && s_editMode > 0) t.tm_hour = checkIncDec(event, t.tm_hour, 0, 23, 0);
               break;
             case 1:
               lcdDrawNumber(lcdNextPos + 1, y, t.tm_min, rowattr|LEADING0|RIGHT, 2);
               lcdDrawChar(lcdNextPos + 1, y, ':');
-              if (rowattr && (s_editMode>0 || p1valdiff)) t.tm_min = checkIncDec(event, t.tm_min, 0, 59, 0);
+              if (rowattr && s_editMode > 0) t.tm_min = checkIncDec(event, t.tm_min, 0, 59, 0);
               break;
             case 2:
               lcdDrawNumber(lcdNextPos + 1, y, t.tm_sec, rowattr|LEADING0|RIGHT, 2);
-              if (rowattr && (s_editMode>0 || p1valdiff)) t.tm_sec = checkIncDec(event, t.tm_sec, 0, 59, 0);
+              if (rowattr && s_editMode > 0) t.tm_sec = checkIncDec(event, t.tm_sec, 0, 59, 0);
               break;
           }
         }

--- a/radio/src/gui/navigation/navigation_9x.cpp
+++ b/radio/src/gui/navigation/navigation_9x.cpp
@@ -27,14 +27,6 @@ uint8_t menuCalibrationState;
 vertpos_t menuVerticalPosition;
 horzpos_t menuHorizontalPosition;
 
-#if defined(NAVIGATION_POT1)
-int16_t p1valdiff;
-#endif
-
-#if defined(NAVIGATION_POT2)
-int8_t p2valdiff;
-#endif
-
 int8_t  checkIncDec_Ret;
 
 #define DBLKEYS_PRESSED_RGT_LFT(in)    ((in & (KEYS_GPIO_PIN_RIGHT + KEYS_GPIO_PIN_LEFT)) == (KEYS_GPIO_PIN_RIGHT + KEYS_GPIO_PIN_LEFT))
@@ -126,14 +118,6 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, unsigned int i_fla
     newval = !val;
   }
 
-#if defined(NAVIGATION_POT1)
-  // change values based on P1
-  newval -= p1valdiff;
-  if (newval < i_min) newval = i_min;
-  else if (newval > i_max) newval = i_max;
-  p1valdiff = 0;
-#endif
-
 #if defined(AUTOSWITCH)
   if (i_flags & INCDEC_SWITCH) {
     newval = checkIncDecMovedSwitch(newval);
@@ -174,7 +158,6 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, unsigned int i_fla
   return newval;
 }
 
-#define SCROLL_TH      64
 #define SCROLL_POT1_TH 32
 
 #define CURSOR_NOT_ALLOWED_IN_ROW(row) ((int8_t)MAXCOL(row) < 0)
@@ -194,36 +177,6 @@ void check(event_t event, uint8_t curr, const MenuHandlerFunc *menuTab, uint8_t 
 
   uint8_t maxcol = MAXCOL(l_posVert);
 
-#if defined(NAVIGATION_POT1)
-  // check pot 1 - if changed -> scroll values
-  static int16_t p1val;
-  static int16_t p1valprev;
-  p1valdiff = (p1val-calibratedAnalogs[CALIBRATED_POT1]) / SCROLL_POT1_TH;
-  if (p1valdiff) {
-    p1valdiff = (p1valprev-calibratedAnalogs[CALIBRATED_POT1]) / 2;
-    p1val = calibratedAnalogs[CALIBRATED_POT1];
-  }
-  p1valprev = calibratedAnalogs[CALIBRATED_POT1];
-#endif
-
-#if defined(NAVIGATION_POT2)
-  // check pot 2 - if changed -> scroll menu
-  static int16_t p2valprev;
-  p2valdiff = (p2valprev-calibratedAnalogs[CALIBRATED_POT2]) / SCROLL_TH;
-  if (p2valdiff) p2valprev = calibratedAnalogs[CALIBRATED_POT2];
-#endif
-
-#if defined(NAVIGATION_POT3)
-  // check pot 3 if changed -> cursor down/up
-  static int16_t p3valprev;
-  int8_t scrollUD = (p3valprev-calibratedAnalogs[CALIBRATED_POT3]) / SCROLL_TH;
-  if (scrollUD) p3valprev = calibratedAnalogs[CALIBRATED_POT3];
-#else
-  #define scrollUD 0
-#endif
-
-  if (p2valdiff || scrollUD || p1valdiff) resetBacklightTimeout(); // on keypress turn the light on
-
   if (menuTab) {
     uint8_t attr = 0;
 
@@ -231,10 +184,6 @@ void check(event_t event, uint8_t curr, const MenuHandlerFunc *menuTab, uint8_t 
       attr = INVERS;
 
       int8_t cc = curr;
-
-      if (p2valdiff) {
-        cc = limit((int8_t)0, (int8_t)(cc - p2valdiff), (int8_t)(menuTabSize-1));
-      }
 
       switch (event) {
 #if defined(ROTARY_ENCODER_NAVIGATION)
@@ -300,19 +249,6 @@ void check(event_t event, uint8_t curr, const MenuHandlerFunc *menuTab, uint8_t 
     menuCalibrationState = 0;
     drawScreenIndex(curr, menuTabSize, attr);
 
-  }
-
-  DISPLAY_PROGRESS_BAR(menuTab ? lcdLastRightPos-2*FW-((curr+1)/10*FWNUM)-2 : 20*FW+1);
-
-  if (s_editMode<=0) {
-    if (scrollUD) {
-      l_posVert = limit((int8_t)0, (int8_t)(l_posVert - scrollUD), (int8_t)maxrow);
-      l_posHorz = min((uint8_t)l_posHorz, MAXCOL(l_posVert));
-    }
-
-    if (p2valdiff && l_posVert>0) {
-      l_posHorz = limit((int8_t)0, (int8_t)((uint8_t)l_posHorz - p2valdiff), (int8_t)maxcol);
-    }
   }
 
   switch (event)

--- a/radio/src/gui/navigation/navigation_9x.cpp
+++ b/radio/src/gui/navigation/navigation_9x.cpp
@@ -158,8 +158,6 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, unsigned int i_fla
   return newval;
 }
 
-#define SCROLL_POT1_TH 32
-
 #define CURSOR_NOT_ALLOWED_IN_ROW(row) ((int8_t)MAXCOL(row) < 0)
 
 #define INC(val, min, max)             if (val<max) {val++;} else {val=min;}

--- a/radio/src/gui/navigation/navigation_x7.cpp
+++ b/radio/src/gui/navigation/navigation_x7.cpp
@@ -230,7 +230,6 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, unsigned int i_fla
   return newval;
 }
 
-#define SCROLL_TH      64
 #define SCROLL_POT1_TH 32
 
 #define CURSOR_NOT_ALLOWED_IN_ROW(row) ((int8_t)MAXCOL(row) < 0)
@@ -284,8 +283,6 @@ void check(event_t event, uint8_t curr, const MenuHandlerFunc * menuTab, uint8_t
 
     drawScreenIndex(curr, menuTabSize, 0);
   }
-
-  DISPLAY_PROGRESS_BAR(menuTab ? lcdLastRightPos-2*FW-((curr+1)/10*FWNUM)-2 : 20*FW+1);
 
   switch (event) {
     case EVT_ENTRY:

--- a/radio/src/gui/navigation/navigation_x7.cpp
+++ b/radio/src/gui/navigation/navigation_x7.cpp
@@ -230,8 +230,6 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, unsigned int i_fla
   return newval;
 }
 
-#define SCROLL_POT1_TH 32
-
 #define CURSOR_NOT_ALLOWED_IN_ROW(row) ((int8_t)MAXCOL(row) < 0)
 
 #define INC(val, min, max)             if (val<max) {val++;} else {val=min;}

--- a/radio/src/gui/navigation/navigation_x9d.cpp
+++ b/radio/src/gui/navigation/navigation_x9d.cpp
@@ -393,8 +393,6 @@ void check(const char * name, event_t event, uint8_t curr, const MenuHandlerFunc
     lcdDrawFilledRect(0, 0, LCD_W, MENU_HEADER_HEIGHT, SOLID, FILL_WHITE|GREY_DEFAULT);
   }
 
-  DISPLAY_PROGRESS_BAR(menuTab ? lcdLastRightPos-2*FW-((curr+1)/10*FWNUM)-2 : 20*FW+1);
-
   switch (event) {
     case EVT_ENTRY:
       menuEntryTime = get_tmr10ms();

--- a/radio/src/gui/navigation/navigation_xlite.cpp
+++ b/radio/src/gui/navigation/navigation_xlite.cpp
@@ -292,7 +292,6 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, unsigned int i_fla
   return newval;
 }
 
-#define SCROLL_TH      64
 #define SCROLL_POT1_TH 32
 
 #define CURSOR_NOT_ALLOWED_IN_ROW(row) ((int8_t)MAXCOL(row) < 0)
@@ -375,8 +374,6 @@ void check(event_t event, uint8_t curr, const MenuHandlerFunc *menuTab, uint8_t 
     drawScreenIndex(curr, menuTabSize, attr);
 
   }
-
-  DISPLAY_PROGRESS_BAR(menuTab ? lcdLastRightPos-2*FW-((curr+1)/10*FWNUM)-2 : 20*FW+1);
 
   switch (event)
   {

--- a/radio/src/gui/navigation/navigation_xlite.cpp
+++ b/radio/src/gui/navigation/navigation_xlite.cpp
@@ -292,8 +292,6 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, unsigned int i_fla
   return newval;
 }
 
-#define SCROLL_POT1_TH 32
-
 #define CURSOR_NOT_ALLOWED_IN_ROW(row) ((int8_t)MAXCOL(row) < 0)
 
 #define INC(val, min, max)             if (val<max) {val++;} else {val=min;}

--- a/radio/src/targets/flysky/CMakeLists.txt
+++ b/radio/src/targets/flysky/CMakeLists.txt
@@ -29,8 +29,6 @@ if(PCB STREQUAL I6X)
   set(AUX_SERIAL_DRIVER ../common/arm/stm32/aux_serial_driver.cpp)
   set(DEFAULT_TEMPLATE_SETUP "0" CACHE STRING "Default channel order")
 
-  # add_definitions(-DNAVIGATION_POT1) # ~324B
-  # add_definitions(-DNAVIGATION_POT2)
   add_definitions(-DSTM32F072)
   add_definitions(-DPWR_BUTTON_${PWR_BUTTON})
   add_definitions(-DEEPROM_VARIANT=0)


### PR DESCRIPTION
- Fixed issue where returning from popup was blocking UP/DOWN navigation,
- added shortcut to go directly to edit mode for empty LS, 
- removed POT navigation code,
- some definitions fixes for excluding not used codepath,

Closes #459 