### PR TITLE
Save RAM: Allocate eeFs only for MAX_MODELS

### DIFF
--- a/radio/src/storage/eeprom_rlc.cpp
+++ b/radio/src/storage/eeprom_rlc.cpp
@@ -164,7 +164,7 @@ void storageFormat()
 
   memclear(&eeFs, sizeof(eeFs));
   eeFs.version  = EEFS_VERS;
-  eeFs.mySize   = sizeof(eeFs);
+  eeFs.mySize   = sizeof(EeFsOld);
   eeFs.freeList = 0;
   eeFs.bs       = BS;
   for (blkid_t i=FIRSTBLK; i<BLOCKS-1; i++) {
@@ -186,12 +186,12 @@ bool eepromOpen()
   if (eeFs.version != EEFS_VERS) {
     TRACE("bad eeFs.version (%d instead of %d)", eeFs.version, EEFS_VERS);
   }
-  if (eeFs.mySize != sizeof(eeFs)) {
-    TRACE("bad eeFs.mySize (%d instead of %d)", (int)eeFs.mySize, (int)sizeof(eeFs));
+  if (eeFs.mySize != sizeof(EeFsOld)) {
+    TRACE("bad eeFs.mySize (%d instead of %d)", (int)eeFs.mySize, (int)sizeof(EeFsOld));
   }
 #endif
 
-  if (eeFs.version != EEFS_VERS || eeFs.mySize != sizeof(eeFs)) {
+  if (eeFs.version != EEFS_VERS || eeFs.mySize != sizeof(EeFsOld)) {
     return false;
   }
 

--- a/radio/src/storage/eeprom_rlc.h
+++ b/radio/src/storage/eeprom_rlc.h
@@ -211,7 +211,7 @@ inline bool isEepromStart(const void * buffer)
   // OpenTX EEPROM
   {
     const EeFs * eeprom = (const EeFs *)buffer;
-    if (eeprom->version==EEFS_VERS && eeprom->mySize==sizeof(eeFs) && eeprom->bs==BS)
+    if (eeprom->version==EEFS_VERS && eeprom->mySize==sizeof(EeFsOld) && eeprom->bs==BS)
       return true;
   }
 

--- a/radio/src/storage/eeprom_rlc.h
+++ b/radio/src/storage/eeprom_rlc.h
@@ -25,7 +25,7 @@
 
   #define blkid_t    uint16_t
   #define EEFS_VERS  5
-  #define MAXFILES   16 + 2 // should be: MAX_MODELS + 1 (FILE_GENERAL) + 1 (FILE_TMP) , 176b RAM wasted in current struct
+  #define MAXFILES   16 + 2 // 62 -> 18, MAX_MODELS + 1 (FILE_GENERAL) + 1 (FILE_TMP) , 176b RAM wasted in current struct
   #define BS         64
 
 PACK(struct DirEnt {
@@ -45,6 +45,16 @@ PACK(struct EeFs {
   DirEnt   files[MAXFILES];
 });
 
+// Previous size of EeFs to keep eeprom alignment
+PACK(struct EeFsOld {
+  uint8_t  version;
+  blkid_t  mySize;
+  blkid_t  freeList;
+  uint8_t  bs;
+  EEFS_EXTRA_FIELDS
+  DirEnt   files[62];
+});
+
 extern EeFs eeFs;
 
 #define FILE_TYP_GENERAL 1
@@ -56,9 +66,7 @@ extern EeFs eeFs;
 #define FILE_MODEL(n) (1+(n))
 #define FILE_TMP      (1+MAX_MODELS)
 
-// Previous size of EeFs to keep eeprom structure untouched but do not allocate unused memory
-#define EEPROM_EEFS_V5_SIZE sizeof(EeFs) + (62 - MAXFILES) * sizeof(DirEnt)
-#define RESV          EEPROM_EEFS_V5_SIZE // sizeof(EeFs)  //reserv for eeprom header with directory (eeFs)
+#define RESV          sizeof(EeFsOld) //   //reserv for eeprom header with directory (eeFs)
 
 #define FIRSTBLK      1
 #define BLOCKS        (1+(EEPROM_SIZE-RESV)/BS)

--- a/radio/src/storage/eeprom_rlc.h
+++ b/radio/src/storage/eeprom_rlc.h
@@ -25,7 +25,7 @@
 
   #define blkid_t    uint16_t
   #define EEFS_VERS  5
-  #define MAXFILES   16 + 2 // 62 -> 18, MAX_MODELS + 1 (FILE_GENERAL) + 1 (FILE_TMP) , 176b RAM wasted in current struct
+  #define MAXFILES   16 + 2 // 62 -> 18, MAX_MODELS + 1 (FILE_GENERAL) + 1 (FILE_TMP)
   #define BS         64
 
 PACK(struct DirEnt {
@@ -45,7 +45,6 @@ PACK(struct EeFs {
   DirEnt   files[MAXFILES];
 });
 
-// Previous size of EeFs to keep eeprom alignment
 PACK(struct EeFsOld {
   uint8_t  version;
   blkid_t  mySize;
@@ -66,7 +65,8 @@ extern EeFs eeFs;
 #define FILE_MODEL(n) (1+(n))
 #define FILE_TMP      (1+MAX_MODELS)
 
-#define RESV          sizeof(EeFsOld) //   //reserv for eeprom header with directory (eeFs)
+// Align to previous size of EeFs to keep eeprom data intact
+#define RESV          sizeof(EeFsOld)  //reserv for eeprom header with directory (eeFs)
 
 #define FIRSTBLK      1
 #define BLOCKS        (1+(EEPROM_SIZE-RESV)/BS)

--- a/radio/src/storage/eeprom_rlc.h
+++ b/radio/src/storage/eeprom_rlc.h
@@ -25,7 +25,7 @@
 
   #define blkid_t    uint16_t
   #define EEFS_VERS  5
-  #define MAXFILES   62
+  #define MAXFILES   16 + 2 // should be: MAX_MODELS + 1 (FILE_GENERAL) + 1 (FILE_TMP) , 176b RAM wasted in current struct
   #define BS         64
 
 PACK(struct DirEnt {
@@ -56,7 +56,9 @@ extern EeFs eeFs;
 #define FILE_MODEL(n) (1+(n))
 #define FILE_TMP      (1+MAX_MODELS)
 
-#define RESV          sizeof(EeFs)  //reserv for eeprom header with directory (eeFs)
+// Previous size of EeFs to keep eeprom structure untouched but do not allocate unused memory
+#define EEPROM_EEFS_V5_SIZE sizeof(EeFs) + (62 - MAXFILES) * sizeof(DirEnt)
+#define RESV          EEPROM_EEFS_V5_SIZE // sizeof(EeFs)  //reserv for eeprom header with directory (eeFs)
 
 #define FIRSTBLK      1
 #define BLOCKS        (1+(EEPROM_SIZE-RESV)/BS)


### PR DESCRIPTION
It seems that eeFs size was hadcoded for 60 models, but our eeprom is smaller and set to MAX_MODELS 16.
- do not allocate eeFS for 60 but 16 MAX_MODELS,
- keep old alignment in eeprom to do not brake structure.

Saves ~176 bytes of RAM