### PR TITLE
Increased max models to 20

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -59,7 +59,7 @@
   #define MAX_TRAINER_CHANNELS         16
   #define MAX_TELEMETRY_SENSORS        32
 #elif defined(PCBI6X)
-  #define MAX_MODELS                   16
+  #define MAX_MODELS                   20
   #define MAX_OUTPUT_CHANNELS          16 // number of real output channels CH1-CH16
   #define MAX_FLIGHT_MODES             5
   #define MAX_MIXERS                   32 

--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -293,14 +293,10 @@ void menuModelSelect(event_t event)
       break;
   }
 
-#if defined(EEPROM_RLC)
+#if defined(EEPROM_RLC) && !defined(PCBI6X) // should not be reached and warning will be raised anyway on low mem
   lcdDrawText(9*FW-(LEN_FREE-4)*FW-4, 0, STR_FREE);
   if (event) reusableBuffer.modelsel.eepromfree = EeFsGetFree();
   lcdDrawNumber(lcdLastRightPos+3, 0, reusableBuffer.modelsel.eepromfree, LEFT);
-#elif defined(EEPROM_RLC)
-  lcdDrawText(9*FW-(LEN_FREE-4)*FW, 0, STR_FREE);
-  if (event) reusableBuffer.modelsel.eepromfree = EeFsGetFree();
-  lcdDrawNumber(17*FW, 0, reusableBuffer.modelsel.eepromfree, RIGHT);
 #endif
 
 #if defined(PCBX7)

--- a/radio/src/gui/128x64/radio_hardware.cpp
+++ b/radio/src/gui/128x64/radio_hardware.cpp
@@ -69,7 +69,7 @@ enum {
   ITEM_RADIO_HARDWARE_DEBUG,
 #endif
 #if defined(EEPROM_RLC)
-#if !defined(PCBI6X)
+#if defined(SDCARD)
   ITEM_RADIO_BACKUP_EEPROM,
 #endif
   ITEM_RADIO_FACTORY_RESET,

--- a/radio/src/storage/eeprom_rlc.h
+++ b/radio/src/storage/eeprom_rlc.h
@@ -25,7 +25,7 @@
 
   #define blkid_t    uint16_t
   #define EEFS_VERS  5
-  #define MAXFILES   16 + 2 // 62 -> 18, MAX_MODELS + 1 (FILE_GENERAL) + 1 (FILE_TMP)
+  #define MAXFILES   MAX_MODELS + 2 // was 62: MAX_MODELS + 1 (FILE_GENERAL) + 1 (FILE_TMP)
   #define BS         64
 
 PACK(struct DirEnt {
@@ -208,21 +208,9 @@ bool eeLoadGeneral();
 // For EEPROM backup/restore
 inline bool isEepromStart(const void * buffer)
 {
-  // OpenTX EEPROM
-  {
-    const EeFs * eeprom = (const EeFs *)buffer;
-    if (eeprom->version==EEFS_VERS && eeprom->mySize==sizeof(EeFsOld) && eeprom->bs==BS)
-      return true;
-  }
-
-  // ersky9x EEPROM
-  {
-    const uint8_t * eeprom = (const uint8_t *)buffer;
-    uint8_t size = eeprom[1] ;
-    uint8_t bs = eeprom[3] ;
-    if (size==0x80 && bs==0x80)
-      return true;
-  }
+  const EeFs * eeprom = (const EeFs *)buffer;
+  if (eeprom->version==EEFS_VERS && eeprom->mySize==sizeof(EeFsOld) && eeprom->bs==BS)
+    return true;
 
   return false;
 }


### PR DESCRIPTION
- Increased max models to 20,
- removed free size counter,
- removed legacy eeprom type check

Tested with 20 /medium/ size models, 2760 B was still left.