### PR TITLE
Enable volume function for DFPlayer

### DIFF
--- a/radio/src/buzzer.h
+++ b/radio/src/buzzer.h
@@ -126,8 +126,6 @@ extern void playModelEvent(uint8_t category, uint8_t index, event_t event=0);
 #define PLAY_FILE(f, id)                dfPlayerQueuePlayFile((f))
 #define AUDIO_FLUSH()               //audioQueue.flush()
 
-#define setScaledVolume(v)
-
 #else // buzzer
 
 extern void pushPrompt(uint16_t prompt);

--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -288,7 +288,7 @@ void evalFunctions(const CustomFunctionData * functions, CustomFunctionsContext 
             }
             break;
 #endif
-#if !defined(PCBI6X)
+#if defined(DFPLAYER)
           case FUNC_VOLUME:
           {
             getvalue_t raw = getValue(CFN_PARAM(cfn));

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -344,8 +344,8 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
               INCDEC_ENABLE_CHECK(functionsContext == &globalFunctionsContext ? isSourceAvailableInGlobalFunctions : isSourceAvailable);
             }
           }
-#endif // SDCARD || DFPLAYER
-#if !defined(PCBI6X)
+#endif // DFPLAYER
+#if defined(DFPLAYER)
           else if (func == FUNC_VOLUME) {
             val_max = MIXSRC_LAST_CH;
             drawSource(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr);

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -46,11 +46,11 @@ enum MenuRadioSetupItems {
   ITEM_SETUP_SOUND_LABEL,
   CASE_AUDIO(ITEM_SETUP_BEEP_MODE)
   CASE_BUZZER(ITEM_SETUP_BUZZER_MODE)
-  // ITEM_SETUP_SPEAKER_VOLUME,
+  CASE_DFPLAYER(ITEM_SETUP_SPEAKER_VOLUME)
   ITEM_SETUP_BEEP_VOLUME,
   ITEM_SETUP_BEEP_LENGTH,
   ITEM_SETUP_SPEAKER_PITCH,
-  CASE_DFPLAYER(ITEM_SETUP_WAV_VOLUME)
+  CASE_AUDIO(ITEM_SETUP_WAV_VOLUME)
   // ITEM_SETUP_BACKGROUND_VOLUME,
   CASE_VARIO(ITEM_SETUP_VARIO_LABEL)
   CASE_VARIO(ITEM_SETUP_VARIO_VOLUME)
@@ -131,7 +131,7 @@ void menuRadioSetup(event_t event)
     HEADER_LINE_COLUMNS CASE_RTCLOCK(2) CASE_RTCLOCK(2) 
     LABEL(SOUND), CASE_AUDIO(0)
     CASE_BUZZER(0)
-    /*0,*/ 0, 0, 0, CASE_DFPLAYER(0) CASE_AUDIO(0)
+    CASE_DFPLAYER(0) 0, 0, 0, CASE_AUDIO(0) /*WAV*/ CASE_AUDIO(0) /*BACKGROUND*/
     CASE_VARIO(LABEL(VARIO))
     CASE_VARIO(0)
     CASE_VARIO(0)
@@ -262,7 +262,7 @@ void menuRadioSetup(event_t event)
         break;
 #endif
 
-#if defined(VOICE)
+#if defined(DFPLAYER)
       case ITEM_SETUP_SPEAKER_VOLUME:
       {
         lcdDrawTextIndented(y, STR_SPEAKER_VOLUME);
@@ -282,14 +282,10 @@ void menuRadioSetup(event_t event)
         g_eeGeneral.beepVolume = slider_5pos(y, g_eeGeneral.beepVolume, event, attr, STR_BEEP_VOLUME);
         break;
 
-#if defined(DFPLAYER)
+#if defined(AUDIO)
       case ITEM_SETUP_WAV_VOLUME:
       {
-        int8_t vol = g_eeGeneral.wavVolume;
         g_eeGeneral.wavVolume = slider_5pos(y, g_eeGeneral.wavVolume, event, attr, STR_WAV_VOLUME);
-        if (vol != g_eeGeneral.wavVolume) {
-          dfplayerSetVolume(g_eeGeneral.wavVolume);
-        }
       }
       break;
 #endif

--- a/radio/src/gui/gui_common_arm.cpp
+++ b/radio/src/gui/gui_common_arm.cpp
@@ -404,7 +404,7 @@ bool isAssignableFunctionAvailable(int function) {
 #else
       return false;
 #endif
-#if defined(PCBI6X) // volume function unsupported
+#if !defined(DFPLAYER)
     case FUNC_VOLUME:
 #endif
 #if !defined(HAPTIC)

--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -20,8 +20,8 @@
 
 #include "opentx.h"
 
-uint8_t currentSpeakerVolume = 255;
-uint8_t requiredSpeakerVolume = 255;
+uint8_t currentSpeakerVolume = VOLUME_LEVEL_MAX;
+uint8_t requiredSpeakerVolume = VOLUME_LEVEL_MAX;
 uint8_t currentBacklightBright = 0;
 uint8_t requiredBacklightBright = 0;
 uint8_t mainRequestFlags = 0;

--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -410,7 +410,14 @@ void perMain()
 {
   DEBUG_TIMER_START(debugTimerPerMain1);
 
-#if defined(AUDIO)
+#if defined(DFPLAYER)
+  // here instead of audioTask
+  // before checkSpeakerVolume because it is more important to play file
+  // than to set volume
+  dfplayerWakeup();
+#endif
+
+#if defined(AUDIO) || defined(DFPLAYER)
   checkSpeakerVolume();
 #endif
 

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -960,7 +960,7 @@ void evalMixes(uint8_t tick10ms)
   // must be done after mixing because some functions use the inputs/channels values
   // must be done before limits because of the applyLimit function: it checks for safety switches which would be not initialized otherwise
   if (tick10ms) {
-#if defined(AUDIO)
+#if defined(AUDIO) || defined(DFPLAYER)
     requiredSpeakerVolume = g_eeGeneral.speakerVolume + VOLUME_LEVEL_DEF;
 #endif
     requiredBacklightBright = g_eeGeneral.backlightBright;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1775,7 +1775,7 @@ void opentxInit()
 #endif
 #if defined(AUDIO)
   currentSpeakerVolume = requiredSpeakerVolume = g_eeGeneral.speakerVolume + VOLUME_LEVEL_DEF;
-  currentBacklightBright = requiredBacklightBright = g_eeGeneral.backlightBright;
+  currentBacklightBright = requiredBacklightBright = g_eeGeneral.backlightBright; // TODO test if needed?
 #if !defined(SOFTWARE_VOLUME)
   setScaledVolume(currentSpeakerVolume);
 #endif
@@ -1785,7 +1785,7 @@ void opentxInit()
 #endif
 
 #if defined(DFPLAYER)
-  dfplayerSetVolume(g_eeGeneral.wavVolume);
+  setScaledVolume(currentSpeakerVolume);
 #endif
 
   BACKLIGHT_ENABLE();

--- a/radio/src/targets/flysky/CMakeLists.txt
+++ b/radio/src/targets/flysky/CMakeLists.txt
@@ -36,7 +36,6 @@ if(PCB STREQUAL I6X)
   add_definitions(-DSTM32F072)
   add_definitions(-DPWR_BUTTON_${PWR_BUTTON})
   add_definitions(-DEEPROM_VARIANT=0)
-  add_definitions(-DSOFTWARE_VOLUME)
   add_definitions(-DAFHDS2A)
   add_definitions(-DCLIPBOARD)
 endif()
@@ -59,6 +58,8 @@ if(DFPLAYER STREQUAL YES)
   ${TARGET_SRC}
   dfplayer_driver.cpp
   )
+else()
+  add_definitions(-DSOFTWARE_VOLUME)
 endif()
 
 if(FAKE_RSSI STREQUAL YES)

--- a/radio/src/targets/flysky/buzzer_driver.cpp
+++ b/radio/src/targets/flysky/buzzer_driver.cpp
@@ -317,13 +317,6 @@ void playTone(uint16_t freq, uint16_t len, uint16_t pause, uint8_t flags, int8_t
 
 void buzzerHeartbeat()
 {
-#if defined(DFPLAYER)
-    uint16_t index;
-    if (!dfPlayerBusy() && dfplayerFifo.pop(index)) {
-      dfplayerPlayFile(index);
-    }
-#endif
-
   if (buzzerState.duration) {
 
     if (buzzerState.duration > 10) {

--- a/radio/src/targets/flysky/dfplayer_driver.cpp
+++ b/radio/src/targets/flysky/dfplayer_driver.cpp
@@ -128,9 +128,9 @@ void dfplayerPlayFile(uint16_t number) {
 }
 
 void setScaledVolume(uint8_t volume) {
-  if (volume > VOLUME_LEVEL_MAX) {
-    volume = VOLUME_LEVEL_MAX;
-  }
+  // if (volume > VOLUME_LEVEL_MAX) {
+  //   volume = VOLUME_LEVEL_MAX;
+  // }
 
   //RTOS_WAIT_MS(200);
   dfplayerCommand(DFP_SET_VOLUME, volume);

--- a/radio/src/targets/flysky/dfplayer_driver.cpp
+++ b/radio/src/targets/flysky/dfplayer_driver.cpp
@@ -104,7 +104,6 @@ const char * audioNames =
   "custm8"
   "custm9";
 
-// #define IS_MIN_CMD_DELAY_ELAPSED() (get_tmr10ms() - dfplayerLastCmdTime > 20) // 200 ms
 #define IS_MIN_PLAY_DELAY_ELAPSED() (get_tmr10ms() - dfplayerLastCmdTime > 80) // 800 ms
 
 static void dfplayerCommand(uint8_t cmd, uint16_t param = 0) {
@@ -128,10 +127,20 @@ void dfplayerPlayFile(uint16_t number) {
     dfplayerCommand(DFP_PLAY, number + 1); // +1 because first file is "zero" and dfplayer uses filesystem index, not filename
 }
 
-void dfplayerSetVolume(int8_t volume) {
-    uint8_t volumes[5] = { 0, 16, 23, 27, 30 }; // range: 0-30
-    //RTOS_WAIT_MS(200);
-    dfplayerCommand(DFP_SET_VOLUME, volumes[volume+2]);
+void setScaledVolume(uint8_t volume) {
+  if (volume > VOLUME_LEVEL_MAX) {
+    volume = VOLUME_LEVEL_MAX;
+  }
+
+  //RTOS_WAIT_MS(200);
+  dfplayerCommand(DFP_SET_VOLUME, volume);
+}
+
+void dfplayerWakeup() {
+  uint16_t index;
+  if (!dfPlayerBusy() && dfplayerFifo.pop(index)) {
+    dfplayerPlayFile(index);
+  }
 }
 
 void dfplayerInit() {
@@ -147,7 +156,7 @@ void dfplayerInit() {
     delay_ms(150); // fix for MH2024K slow init
 
     aux3SerialInit();
-    dfplayerSetVolume(0); // default volume
+    // dfplayerSetVolume(0); // default volume, done in opentxInit
     
     if (!globalData.unexpectedShutdown) {
         AUDIO_HELLO();

--- a/radio/src/targets/flysky/dfplayer_driver.h
+++ b/radio/src/targets/flysky/dfplayer_driver.h
@@ -17,6 +17,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+#include <stddef.h>
 
 #ifndef _DFPLAYER_DRIVER_H_
 #define _DFPLAYER_DRIVER_H_
@@ -36,9 +37,11 @@
 
 extern const char * audioNames;
 
+extern uint8_t currentSpeakerVolume;
+
 void dfplayerPlayFile(uint16_t number);
 void dfplayerInit(void);
-void dfplayerSetVolume(int8_t);
+void dfplayerWakeup(void);
 bool dfPlayerBusy(void);
 void dfPlayerQueuePlayFile(uint16_t);
 // void dfPlayerQueueStopPlay(uint8_t id);


### PR DESCRIPTION
- Enable Volume special function for DFPlayer,
- move DFPlayer handling from ISR to menu task,
- replace Radio Setup Wav volume with Volume option that have better granularity vs only 5 volume steps.

Closes #471 