### PR TITLE
Add configurable stick axis inversion for FlySky I6X builds

### DIFF
--- a/radio/src/targets/flysky/CMakeLists.txt
+++ b/radio/src/targets/flysky/CMakeLists.txt
@@ -8,6 +8,10 @@ option(AFHDS2A_LQI_CH "Send RSSI at channel 1-17" OFF)
 option(DFPLAYER "Enables DFPlayer on AUX3 TX" NO) # ~1.7kB
 option(FAKE_RSSI "Enables converting TRSS to RSSI data for receivers not sending RSSI" NO)
 option(SBUS_TRAINER "Enables SBUS Trainer mode and trainer lost/back sounds" NO) # ~0.6kB
+option(PCBI6X_INV_CH1 "Invert CH1" NO)
+option(PCBI6X_INV_CH2 "Invert CH2" NO)
+option(PCBI6X_INV_CH3 "Invert CH3" NO)
+option(PCBI6X_INV_CH4 "Invert CH4" NO)
 
 if(PCB STREQUAL I6X)
   set(PWR_BUTTON "SWITCH" CACHE STRING "Pwr button type (PRESS/SWITCH)")
@@ -109,6 +113,22 @@ if(SBUS_TRAINER STREQUAL YES)
     ${PULSES_SRC}
     ../sbus.cpp
     )
+endif()
+
+if(PCBI6X_INV_CH1 STREQUAL YES)
+  add_definitions(-DPCBI6X_INV_CH1)
+endif()
+
+if(PCBI6X_INV_CH2 STREQUAL YES)
+  add_definitions(-DPCBI6X_INV_CH2)
+endif()
+
+if(PCBI6X_INV_CH3 STREQUAL YES)
+  add_definitions(-DPCBI6X_INV_CH3)
+endif()
+
+if(PCBI6X_INV_CH4 STREQUAL YES)
+  add_definitions(-DPCBI6X_INV_CH4)
 endif()
 
 set(HSE_VALUE 8000000)

--- a/radio/src/targets/flysky/adc_driver.cpp
+++ b/radio/src/targets/flysky/adc_driver.cpp
@@ -20,10 +20,38 @@
 
 #include "opentx.h"
 
+#if defined(PCBI6X_INV_CH1)
+#define ADC_DIR_CH1 -1
+#pragma message("CH1 invert active")
+#else
+#define ADC_DIR_CH1 1
+#endif
+
+#if defined(PCBI6X_INV_CH2)
+#define ADC_DIR_CH2 -1
+#pragma message("CH2 invert active")
+#else
+#define ADC_DIR_CH2 1
+#endif
+
+#if defined(PCBI6X_INV_CH3)
+#define ADC_DIR_CH3 -1
+#pragma message("CH3 invert active")
+#else
+#define ADC_DIR_CH3 1
+#endif
+
+#if defined(PCBI6X_INV_CH4)
+#define ADC_DIR_CH4 -1
+#pragma message("CH4 invert active")
+#else
+#define ADC_DIR_CH4 1
+#endif
+
 #if defined(SIMU)
 // not needed
 #else
-const int8_t ana_direction[NUM_ANALOGS] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0};
+const int8_t ana_direction[NUM_ANALOGS] = {ADC_DIR_CH4, ADC_DIR_CH3, ADC_DIR_CH2, ADC_DIR_CH1, 1, 1, 1, 1, 1, 1, 0};
 #if defined (FLYSKY_GIMBAL)
 const uint8_t ana_mapping[NUM_ANALOGS] =  {0, 1, 2, 3, 6, 7, 4, 5, 8, 9, 10};
 #else


### PR DESCRIPTION
## Description:
This PR adds new CMake options to allow users to invert stick axes without modifying code manually.
The options can be passed via CMAKE_FLAGS in the Docker build process, similar to existing flags like PCBI6X_ELRS.

### New CMake options:

- `PCBI6X_INV_CH1=YES` → Invert Channel 1 (AIL)
- `PCBI6X_INV_CH2=YES` → Invert Channel 2 (ELE)
- `PCBI6X_INV_CH3=YES` → Invert Channel 3 (THR)
- `PCBI6X_INV_CH4=YES` → Invert Channel 4 (RUD)

### Example Docker build command:

```bash
docker run --rm -it -e "BOARD_NAME=i6x" -e "CMAKE_FLAGS=PCB=I6X HELI=NO GVARS=YES PCBI6X_INAV=NO
PCBI6X_ELRS=YES DFPLAYER=YES USB_MSD=YES USB_SERIAL=YES SBUS_TRAINER=YES TRANSLATIONS=EN DEBUG=NO
PCBI6X_INV_CH1=YES PCBI6X_INV_CH3=YES" -v ${PWD}:/opentx ajjjjjjjj/opentx-docker-i6x
```

This allows more flexibility for users who wnat to change the orientation gimbals without changing the firmware itself.

## Documentation:
The Development Wiki should be updated to include these new flags. Suggested snippet for Wiki: 

# Development

## Selected build time options

| Option | Values | Description |
|--------|--------|-------------|
| *(previous columns)* | | |
| `PCBI6X_INV_CH1` | `YES`/`NO` | Invert CH1 axis |
| `PCBI6X_INV_CH2` | `YES`/`NO` | Invert CH2 axis |
| `PCBI6X_INV_CH3` | `YES`/`NO` | Invert CH3 axis |
| `PCBI6X_INV_CH4` | `YES`/`NO` | Invert CH4 axis |

The Modifications Wiki might be updated to include a hint to these new flags. Suggested snippet for Wiki:

# Modifucations 

...

## Stick Axis Inversion for HALL Gimbal Mod
You can invert individual stick axes during build using the following flags:

- `PCBI6X_INV_CH1=YES` → invert Aileron
- `PCBI6X_INV_CH2=YES` → invert Elevator
- `PCBI6X_INV_CH3=YES` → invert Throttle
- `PCBI6X_INV_CH4=YES` → invert Rudder

**Example:**
```bash
docker run --rm -it -e "BOARD_NAME=i6x" -e "CMAKE_FLAGS=PCB=I6X HELI=NO GVARS=YES PCBI6X_INAV=NO
PCBI6X_ELRS=YES DFPLAYER=YES USB_MSD=YES USB_SERIAL=YES SBUS_TRAINER=YES TRANSLATIONS=EN DEBUG=NO
PCBI6X_INV_CH1=YES PCBI6X_INV_CH3=YES" -v ${PWD}:/opentx ajjjjjjjj/opentx-docker-i6x
```