### PR TITLE
CRSF improvements

### DIFF
--- a/radio/src/targets/flysky/tools/elrs.cpp
+++ b/radio/src/targets/flysky/tools/elrs.cpp
@@ -194,7 +194,7 @@ static void crossfireTelemetryCmd(const uint8_t cmd, const uint8_t index, const 
   crossfireTelemetryCmd(cmd, index, &value, 1);
 }
 
-static void crossfireTelemetryPing(){
+static void crossfireTelemetryPing() {
   const uint8_t crsfPushData[2] = { 0x00, 0xEA };
   crossfireTelemetryPush(CRSF_FRAMETYPE_DEVICE_PING, (uint8_t *) crsfPushData, 2);
 }
@@ -566,7 +566,7 @@ static void parseDeviceInfoMessage(uint8_t* data) {
       expectedParamsCount = newParamCount;
       clearParams();
       if (newParamCount == 0) {
-      // This device has no params so the Loading code never starts
+        // This device has no params so the Loading code never starts
         allParamsLoaded = 1;
       }
     }
@@ -773,7 +773,7 @@ static void lcd_title() {
     luaLcdDrawGauge(0, 1, COL2, barHeight, paramId, expectedParamsCount);
   } else {
     const char* textToDisplay = titleShowWarn ? elrsFlagsInfo :
-                            (allParamsLoaded == 1) ? (char *)&deviceName[0] : "External TX...";
+                            (allParamsLoaded == 1) ? (char *)&deviceName[0] : TR_EXTERNALRF; // "External TX...";
     uint8_t textLen = titleShowWarn ? ELRS_FLAGS_INFO_MAX_LEN : DEVICE_NAME_MAX_LEN;
     lcdDrawSizedText(COL1, 1, textToDisplay, textLen, INVERS);
   }

--- a/radio/src/targets/flysky/tools/elrs.cpp
+++ b/radio/src/targets/flysky/tools/elrs.cpp
@@ -737,7 +737,7 @@ static void refreshNext() {
   } else if (time > paramTimeout && expectedParamsCount != 0) {
     if (allParamsLoaded < 1) {
       crossfireTelemetryCmd(CRSF_FRAMETYPE_PARAMETER_READ, paramId, paramChunk);
-      paramTimeout = time + 500; // 5s
+      paramTimeout = time + ((deviceIsELRS_TX) ? 50 : 500); // 0.5s for local / 5s for remote devices
     }
   }
 
@@ -771,7 +771,7 @@ static void lcd_title() {
     luaLcdDrawGauge(0, 1, COL2, barHeight, paramId, expectedParamsCount);
   } else {
     const char* textToDisplay = titleShowWarn ? elrsFlagsInfo :
-                            (allParamsLoaded == 1) ? (char *)&deviceName[0] : "Loading...";
+                            (allParamsLoaded == 1) ? (char *)&deviceName[0] : "External TX...";
     uint8_t textLen = titleShowWarn ? ELRS_FLAGS_INFO_MAX_LEN : DEVICE_NAME_MAX_LEN;
     lcdDrawSizedText(COL1, 1, textToDisplay, textLen, INVERS);
   }

--- a/radio/src/targets/flysky/tools/elrs.cpp
+++ b/radio/src/targets/flysky/tools/elrs.cpp
@@ -5,29 +5,31 @@
  */
 #include "opentx.h"
 
-enum COMMAND_STEP {
-    STEP_IDLE = 0,
-    STEP_CLICK = 1,       // user has clicked the command to execute
-    STEP_EXECUTING = 2,   // command is executing
-    STEP_CONFIRM = 3,     // command pending user OK
-    STEP_CONFIRMED = 4,   // user has confirmed
-    STEP_CANCEL = 5,      // user has requested cancel
-    STEP_QUERY = 6,       // UI is requesting status update
+enum cmd_status {
+    STATUS_READY = 0,
+    STATUS_START = 1,       // user has clicked the command to execute
+    STATUS_PROGRESS = 2,   // command is executing
+    STATUS_CONFIRMATION_NEEDED = 3,     // command pending user OK
+    STATUS_CONFIRM = 4,   // user has confirmed
+    STATUS_CANCEL = 5,      // user has requested cancel
+    STATUS_POLL = 6,       // UI is requesting status update
 };
 
-#define TYPE_UINT8				   0
-#define TYPE_INT8				   1
-#define TYPE_UINT16				   2
-#define TYPE_INT16				   3
-#define TYPE_FLOAT				   8
-#define TYPE_SELECT                9
-#define TYPE_STRING				  10
-#define TYPE_FOLDER				  11
-#define TYPE_INFO				  12
-#define TYPE_COMMAND			  13
-#define TYPE_BACK                 14
-#define TYPE_DEVICE               15
-#define TYPE_DEVICES_FOLDER       16
+enum data_type {
+    TYPE_UINT8 = 0,
+    TYPE_INT8 = 1,
+    TYPE_UINT16 = 2,
+    TYPE_INT16 = 3,
+    TYPE_FLOAT = 8,
+    TYPE_SELECT = 9,
+    TYPE_STRING = 10,
+    TYPE_FOLDER = 11,
+    TYPE_INFO = 12,
+    TYPE_COMMAND = 13,
+    TYPE_BACK = 14,
+    TYPE_DEVICE = 15,
+    TYPE_DEVICES_FOLDER = 16
+};
 
 #define CRSF_FRAMETYPE_DEVICE_PING 0x28
 #define CRSF_FRAMETYPE_DEVICE_INFO 0x29
@@ -468,17 +470,17 @@ static void paramCommandLoad(Parameter * param, uint8_t * data, uint8_t offset) 
   param->status = data[offset];
   param->timeout = data[offset+1];
   param->infoOffset = offset+2; // do not copy info, access directly
-  if (param->status == STEP_IDLE) {
+  if (param->status == STATUS_READY) {
     paramPopup = nullptr;
   }
 }
 
 static void paramCommandSave(Parameter * param) {
-  if (param->status < STEP_CONFIRMED) {
-    param->status = STEP_CLICK;
+  if (param->status < STATUS_CONFIRM) {
+    param->status = STATUS_START;
     crossfireTelemetryCmd(CRSF_FRAMETYPE_PARAMETER_WRITE, param->id, param->status);
     paramPopup = param;
-    paramPopup->lastStatus = STEP_IDLE;
+    paramPopup->lastStatus = STATUS_READY;
     paramTimeout = getTime() + param->timeout;
   }
 }
@@ -727,8 +729,8 @@ static void refreshNextCallback(uint8_t command, uint8_t* data, uint8_t length) 
 static void refreshNext() {
   tmr10ms_t time = getTime();
   if (paramPopup != nullptr) {
-    if (time > paramTimeout && paramPopup->status != STEP_CONFIRM) {
-      crossfireTelemetryCmd(CRSF_FRAMETYPE_PARAMETER_WRITE, paramPopup->id, STEP_QUERY);
+    if (time > paramTimeout && paramPopup->status != STATUS_CONFIRMATION_NEEDED) {
+      crossfireTelemetryCmd(CRSF_FRAMETYPE_PARAMETER_WRITE, paramPopup->id, STATUS_POLL);
       paramTimeout = time + paramPopup->timeout;
     }
   } else if (time > devicesRefreshTimeout && expectedParamsCount < 1) {
@@ -906,30 +908,30 @@ static uint8_t popupCompat(event_t event) {
 
 static void runPopupPage(event_t event) {
   if (event == EVT_VIRTUAL_EXIT) {
-    crossfireTelemetryCmd(CRSF_FRAMETYPE_PARAMETER_WRITE, paramPopup->id, STEP_CANCEL);
+    crossfireTelemetryCmd(CRSF_FRAMETYPE_PARAMETER_WRITE, paramPopup->id, STATUS_CANCEL);
     paramTimeout = getTime() + 200;
   }
 
   uint8_t result = RESULT_NONE;
-  if (paramPopup->status == STEP_IDLE && paramPopup->lastStatus != STEP_IDLE) { // stopped
+  if (paramPopup->status == STATUS_READY && paramPopup->lastStatus != STATUS_READY) { // stopped
       popupCompat(event);
       reloadAllParam();
       paramPopup = nullptr;
-  } else if (paramPopup->status == STEP_CONFIRM) { // confirmation required
+  } else if (paramPopup->status == STATUS_CONFIRMATION_NEEDED) { // confirmation required
     result = popupCompat(event);
     paramPopup->lastStatus = paramPopup->status;
     if (result == RESULT_OK) {
-      crossfireTelemetryCmd(CRSF_FRAMETYPE_PARAMETER_WRITE, paramPopup->id, STEP_CONFIRMED);
+      crossfireTelemetryCmd(CRSF_FRAMETYPE_PARAMETER_WRITE, paramPopup->id, STATUS_CONFIRM);
       paramTimeout = getTime() + paramPopup->timeout; // we are expecting an immediate response
-      paramPopup->status = STEP_CONFIRMED;
+      paramPopup->status = STATUS_CONFIRM;
     } else if (result == RESULT_CANCEL) {
       paramPopup = nullptr;
     }
-  } else if (paramPopup->status == STEP_EXECUTING) {
+  } else if (paramPopup->status == STATUS_PROGRESS) {
     result = popupCompat(event);
     paramPopup->lastStatus = paramPopup->status;
     if (result == RESULT_CANCEL) {
-      crossfireTelemetryCmd(CRSF_FRAMETYPE_PARAMETER_WRITE, paramPopup->id, STEP_CANCEL);
+      crossfireTelemetryCmd(CRSF_FRAMETYPE_PARAMETER_WRITE, paramPopup->id, STATUS_CANCEL);
       paramTimeout = getTime() + paramPopup->timeout;
       paramPopup = nullptr;
     }

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -56,6 +56,7 @@ const CrossfireSensor crossfireSensors[] = {
   {CF_RPM_ID,      0, ZSTR_RPM,          UNIT_RPMS,            0},
   {TEMP_ID,        0, ZSTR_TEMP,         UNIT_TEMPERATURE,     1},
   {CELLS_ID,       0, ZSTR_CELLS,        UNIT_CELLS,           2},
+  {VOLT_ARRAY_ID,  0, ZSTR_VOLT,         UNIT_VOLTS,           2},
   {0,              0, "UNKNOWN",          UNIT_RAW,            0},
 };
 
@@ -88,6 +89,8 @@ const CrossfireSensor &getCrossfireSensor(uint8_t id, uint8_t subId) {
     return crossfireSensors[TEMP_INDEX];
   else if (id == CELLS_ID)
     return crossfireSensors[CELLS_INDEX];
+  else if (id == VOLT_ARRAY_ID)
+    return crossfireSensors[VOLT_ARRAY_INDEX];
   else
     return crossfireSensors[UNKNOWN_INDEX];
 }
@@ -211,12 +214,23 @@ void processCrossfireTelemetryFrame() {
       getCrossfireTelemetryValue<1>(3, value);
       uint8_t sensorID = value;
 
-      // We can handle only up to 6 cells
-      for(uint8_t i = 0; i * 2 < min(6 * 2, crsfPayloadLen - 4);  i++) {
-        getCrossfireTelemetryValue<2>(4 + i * 2, value);
-        const CrossfireSensor & sensor = crossfireSensors[CELLS_INDEX];
-        setTelemetryValue(PROTOCOL_TELEMETRY_CROSSFIRE, sensor.id + (sensorID << 8), 0, 0,
+     if (sensorID < 128) {
+        // Treating frame as Cells sensor
+        // We can handle only up to 6 cells
+        for(uint8_t i = 0; i * 2 < min(6 * 2, crsfPayloadLen - 4);  i++) {
+          getCrossfireTelemetryValue<2>(4 + i * 2, value);
+          const CrossfireSensor & sensor = crossfireSensors[CELLS_INDEX];
+          setTelemetryValue(PROTOCOL_TELEMETRY_CROSSFIRE, sensor.id + (sensorID << 8), 0, 0,
                           i << 16 | value / 10, sensor.unit, sensor.precision);
+        }
+      } else {
+        // Treating frame as Voltage sensor array
+        for(uint8_t i = 0; i * 2 < (crsfPayloadLen - 4);  i++) {
+          value = (telemetryRxBuffer[4 + i * 2] << 8) + telemetryRxBuffer[4 + i * 2 + 1];
+          const CrossfireSensor & sensor = crossfireSensors[VOLT_ARRAY_INDEX];
+          setTelemetryValue(PROTOCOL_TELEMETRY_CROSSFIRE, sensor.id + (sensorID << 8), 0, i,
+                                    value / 10, sensor.unit, sensor.precision);
+        }
       }
       break;
     }

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -39,6 +39,7 @@
 #define CF_RPM_ID                      0x0C
 #define TEMP_ID                        0x0D
 #define CELLS_ID                       0x0E
+#define VOLT_ARRAY_ID                  0xFE // Pseudo sensor out of 0x0E frame
 #define LINK_ID                        0x14
 #define CHANNELS_ID                    0x16
 #define LINK_RX_ID                     0x1C
@@ -100,6 +101,7 @@ enum CrossfireSensorIndexes {
   CF_RPM_INDEX,
   TEMP_INDEX,
   CELLS_INDEX,
+  VOLT_ARRAY_INDEX,
   UNKNOWN_INDEX,
 };
 

--- a/radio/src/translations/cz.h.txt
+++ b/radio/src/translations/cz.h.txt
@@ -1219,6 +1219,7 @@
 #define ZSTR_A2                "A2"
 #define ZSTR_A3                "A3"
 #define ZSTR_A4                "A4"
+#define ZSTR_VOLT              "Volt"
 #define ZSTR_BATT              "RxBt"
 #define ZSTR_ALT               "Alt"
 #define ZSTR_TEMP             "Temp"

--- a/radio/src/translations/de.h.txt
+++ b/radio/src/translations/de.h.txt
@@ -1220,6 +1220,7 @@
 #define ZSTR_A2                "A2"
 #define ZSTR_A3                "A3"
 #define ZSTR_A4                "A4"
+#define ZSTR_VOLT              "Volt"
 #define ZSTR_BATT              "RxBt"
 #define ZSTR_ALT               "Alt"
 #define ZSTR_TEMP             "Temp"

--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -1221,6 +1221,7 @@
 #define ZSTR_A2                        "A2"
 #define ZSTR_A3                        "A3"
 #define ZSTR_A4                        "A4"
+#define ZSTR_VOLT                      "Volt"
 #define ZSTR_BATT                      "RxBt"
 #define ZSTR_ALT                       "Alt"
 #define ZSTR_TEMP             "Temp"

--- a/radio/src/translations/es.h.txt
+++ b/radio/src/translations/es.h.txt
@@ -1225,6 +1225,7 @@
 #define ZSTR_A2                "A2"
 #define ZSTR_A3                "A3"
 #define ZSTR_A4                "A4"
+#define ZSTR_VOLT              "Volt"
 #define ZSTR_BATT              "RxBt"
 #define ZSTR_ALT               "Alt"
 #define ZSTR_TEMP             "Temp"

--- a/radio/src/translations/fi.h.txt
+++ b/radio/src/translations/fi.h.txt
@@ -1204,6 +1204,7 @@
 #define ZSTR_A2                "A2"
 #define ZSTR_A3                "A3"
 #define ZSTR_A4                "A4"
+#define ZSTR_VOLT              "Volt"
 #define ZSTR_BATT              "RxBt"
 #define ZSTR_ALT               "Alt"
 #define ZSTR_TEMP             "Temp"

--- a/radio/src/translations/fr.h.txt
+++ b/radio/src/translations/fr.h.txt
@@ -1231,6 +1231,7 @@
 #define ZSTR_A2                        "A2"
 #define ZSTR_A3                        "A3"
 #define ZSTR_A4                        "A4"
+#define ZSTR_VOLT                      "Volt"
 #define ZSTR_BATT                      "BtRx"
 #define ZSTR_ALT                       "Alt"
 #define ZSTR_TEMP             "Temp"

--- a/radio/src/translations/it.h.txt
+++ b/radio/src/translations/it.h.txt
@@ -1218,6 +1218,7 @@
 #define ZSTR_A2                "A2"
 #define ZSTR_A3                "A3"
 #define ZSTR_A4                "A4"
+#define ZSTR_VOLT              "Volt"
 #define ZSTR_BATT              "RxBt"
 #define ZSTR_ALT               "Alt"
 #define ZSTR_TEMP             "Temp"

--- a/radio/src/translations/nl.h.txt
+++ b/radio/src/translations/nl.h.txt
@@ -1218,6 +1218,7 @@
 #define ZSTR_A2                "A2"
 #define ZSTR_A3                "A3"
 #define ZSTR_A4                "A4"
+#define ZSTR_VOLT              "Volt"
 #define ZSTR_BATT              "RxBt"
 #define ZSTR_ALT               "Alt"
 #define ZSTR_TEMP             "Temp"

--- a/radio/src/translations/pl.h.txt
+++ b/radio/src/translations/pl.h.txt
@@ -1221,6 +1221,7 @@
 #define ZSTR_A2                "A2"
 #define ZSTR_A3                "A3"
 #define ZSTR_A4                "A4"
+#define ZSTR_VOLT              "Volt"
 #define ZSTR_BATT              "RxBt"
 #define ZSTR_ALT               "Alt"
 #define ZSTR_TEMP             "Temp"

--- a/radio/src/translations/pt.h.txt
+++ b/radio/src/translations/pt.h.txt
@@ -1221,6 +1221,7 @@
 #define ZSTR_A2                "A2"
 #define ZSTR_A3                "A3"
 #define ZSTR_A4                "A4"
+#define ZSTR_VOLT              "Volt"
 #define ZSTR_BATT              "RxBt"
 #define ZSTR_ALT               "Alt"
 #define ZSTR_TEMP             "Temp"

--- a/radio/src/translations/se.h.txt
+++ b/radio/src/translations/se.h.txt
@@ -1227,6 +1227,7 @@
 #define ZSTR_A2                "A2"
 #define ZSTR_A3                "A3"
 #define ZSTR_A4                "A4"
+#define ZSTR_VOLT              "Volt"
 #define ZSTR_BATT              "RxBt"
 #define ZSTR_ALT               "Alt"
 #define ZSTR_TEMP             "Temp"


### PR DESCRIPTION
* Ported recent ExpressLRS LUA changes,
* use step naming closer to official CRSF spec,
* allow CRSF cells or volt array for frame 0x0E (EdgeTX/edgetx#6361 port)