### PR TITLE
Fix CSRF frame header recognition logic, driver fix

### DIFF
--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -166,7 +166,7 @@ extern "C" void TELEMETRY_DMA_TX_IRQHandler(void) {
   if (DMA_GetITStatus(TELEMETRY_DMA_TX_FLAG_TC)) {
     DMA_ClearITPendingBit(TELEMETRY_DMA_TX_FLAG_TC);
     // clear TC flag before enabling interrupt
-    TELEMETRY_USART->ISR &= ~USART_ISR_TC;
+    TELEMETRY_USART->ICR = USART_ICR_TCCF;
     TELEMETRY_USART->CR1 |= USART_CR1_TCIE;
   }
 }
@@ -177,11 +177,13 @@ extern "C" void TELEMETRY_USART_IRQHandler(void) {
 
   // TX, transfer complete
   if ((status & USART_ISR_TC) && (TELEMETRY_USART->CR1 & USART_CR1_TCIE)) {
+    // disable TC IRQ
     TELEMETRY_USART->CR1 &= ~USART_CR1_TCIE;
+
     telemetryPortSetDirectionInput();
-    while (status & (USART_FLAG_RXNE)) {
-      status = TELEMETRY_USART->RDR;
-      status = TELEMETRY_USART->ISR;
+    
+    while (TELEMETRY_USART->ISR & USART_FLAG_RXNE) {
+      (void)TELEMETRY_USART->RDR;
     }
   }
 

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -292,7 +292,8 @@ void processCrossfireTelemetryFrame() {
         processCrossfireTelemetryValue(ATTITUDE_YAW_INDEX, value / 10);
       break;
 
-    case FLIGHT_MODE_ID: {
+    case FLIGHT_MODE_ID:
+    {
       const CrossfireSensor &sensor = crossfireSensors[FLIGHT_MODE_INDEX];
       auto textLength = min<int>(16, telemetryRxBuffer[1]);
       telemetryRxBuffer[textLength] = '\0';
@@ -409,7 +410,7 @@ void processCrossfireTelemetryData(uint8_t data) {
   }
 #endif
 
-  if (telemetryRxBufferCount == 0 && data != RADIO_ADDRESS) {
+  if (telemetryRxBufferCount == 0 && !(data == RADIO_ADDRESS || data == UART_SYNC)) {
     TRACE("[XF] addr 0x%02X err", data);
     return;
   }


### PR DESCRIPTION
This fixes missing telemetry on ExpressLRS V4.0.
Adjusted header recognition to match EdgeTX logic.

Closes #492 