### PR TITLE
Added menu entry *Cpy min/max to all* in MODEL/OUTPUT

### DIFF
--- a/radio/src/gui/128x64/model_outputs.cpp
+++ b/radio/src/gui/128x64/model_outputs.cpp
@@ -206,6 +206,9 @@ void onLimitsMenu(const char *result)
   else if (result == STR_EDIT) {
     pushMenu(menuModelLimitsOne);
   }
+  else if (result == STR_COPY_MIN_MAX_TO_OUTPUTS) {
+    copyMinMaxToOutputs(s_currIdx);
+  }
 }
 
 void menuModelLimits(event_t event)
@@ -227,7 +230,7 @@ void menuModelLimits(event_t event)
     if (sub==k && event==EVT_KEY_FIRST(KEY_ENTER) && !READ_ONLY() && (k != MAX_OUTPUT_CHANNELS) ) {
       killEvents(event);
       s_editMode = 0;
-      POPUP_MENU_START(onLimitsMenu, 4, STR_EDIT, STR_RESET, STR_COPY_TRIMS_TO_OFS, STR_COPY_STICKS_TO_OFS);
+      POPUP_MENU_START(onLimitsMenu, 5, STR_EDIT, STR_RESET, STR_COPY_TRIMS_TO_OFS, STR_COPY_STICKS_TO_OFS,STR_COPY_MIN_MAX_TO_OUTPUTS);
     }
 
     if (k == MAX_OUTPUT_CHANNELS) {

--- a/radio/src/gui/212x64/model_outputs.cpp
+++ b/radio/src/gui/212x64/model_outputs.cpp
@@ -86,6 +86,9 @@ void onLimitsMenu(const char *result)
     copyTrimsToOffset(ch);
     storageDirty(EE_MODEL);
   }
+  else if (result == STR_COPY_MIN_MAX_TO_OUTPUTS) {
+    copyMinMaxToOutputs(ch);
+  }
 }
 
 void menuModelLimits(event_t event)
@@ -142,6 +145,7 @@ void menuModelLimits(event_t event)
       POPUP_MENU_ADD_ITEM(STR_RESET);
       POPUP_MENU_ADD_ITEM(STR_COPY_TRIMS_TO_OFS);
       POPUP_MENU_ADD_ITEM(STR_COPY_STICKS_TO_OFS);
+      POPUP_MENU_ADD_ITEM(STR_COPY_MIN_MAX_TO_OUTPUTS);
       POPUP_MENU_START(onLimitsMenu);
     }
 

--- a/radio/src/gui/480x272/model_outputs.cpp
+++ b/radio/src/gui/480x272/model_outputs.cpp
@@ -80,6 +80,9 @@ void onLimitsMenu(const char *result)
     copyTrimsToOffset(ch);
     storageDirty(EE_MODEL);
   }
+  else if (result == STR_COPY_MIN_MAX_TO_OUTPUTS) {
+    copyMinMaxToOutputs(ch);
+  }
 }
 
 bool menuModelLimits(event_t event)
@@ -133,6 +136,7 @@ bool menuModelLimits(event_t event)
       POPUP_MENU_ADD_ITEM(STR_RESET);
       POPUP_MENU_ADD_ITEM(STR_COPY_TRIMS_TO_OFS);
       POPUP_MENU_ADD_ITEM(STR_COPY_STICKS_TO_OFS);
+      POPUP_MENU_ADD_ITEM(STR_COPY_MIN_MAX_TO_OUTPUTS);
       POPUP_MENU_START(onLimitsMenu);
     }
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1519,6 +1519,26 @@ void copyTrimsToOffset(uint8_t ch) {
   storageDirty(EE_MODEL);
 }
 
+void copyMinMaxToOutputs(uint8_t ch)
+{
+  LimitData *ld = limitAddress(ch);
+  int16_t min = ld->min;
+  int16_t max = ld->max;
+  int16_t center = ld->ppmCenter;
+
+  pauseMixerCalculations();
+
+  for (uint8_t chan = 0; chan < MAX_OUTPUT_CHANNELS; chan++) {
+    ld = limitAddress(chan);
+    ld->min = min;
+    ld->max = max;
+    ld->ppmCenter = center;
+  }
+
+  resumeMixerCalculations();
+  storageDirty(EE_MODEL);
+}
+
 void moveTrimsToOffsets()  // copy state of 3 primary to subtrim
 {
   int16_t zeros[MAX_OUTPUT_CHANNELS];

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -819,6 +819,7 @@ void instantTrim();
 void evalTrims();
 void copyTrimsToOffset(uint8_t ch);
 void copySticksToOffset(uint8_t ch);
+void copyMinMaxToOutputs(uint8_t ch);
 void moveTrimsToOffsets();
 
 typedef uint16_t ACTIVE_PHASES_TYPE;

--- a/radio/src/translations.cpp
+++ b/radio/src/translations.cpp
@@ -665,6 +665,7 @@ const char STR_BLCOLOR[]   = TR_BLCOLOR;
   const char STR_PTS[]  = TR_PTS;
   const char STR_SMOOTH[]  = TR_SMOOTH;
   const char STR_COPY_STICKS_TO_OFS[]  = TR_COPY_STICKS_TO_OFS;
+  const char STR_COPY_MIN_MAX_TO_OUTPUTS[]  = TR_COPY_MIN_MAX_TO_OUTPUTS;
   const char STR_COPY_TRIMS_TO_OFS[]  = TR_COPY_TRIMS_TO_OFS;
   const char STR_INCDEC[]  = TR_INCDEC;
   const char STR_GLOBALVAR[]  = TR_GLOBALVAR;

--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -941,6 +941,7 @@ extern const char STR_BLCOLOR[];
   extern const char STR_PTS[];
   extern const char STR_SMOOTH[];
   extern const char STR_COPY_STICKS_TO_OFS[];
+  extern const char STR_COPY_MIN_MAX_TO_OUTPUTS[];
   extern const char STR_COPY_TRIMS_TO_OFS[];
   extern const char STR_INCDEC[];
   extern const char STR_GLOBALVAR[];

--- a/radio/src/translations/cz.h.txt
+++ b/radio/src/translations/cz.h.txt
@@ -1014,6 +1014,7 @@
 #define TR_PTS                 " b."
 #define TR_SMOOTH              "Hladká"
 #define TR_COPY_STICKS_TO_OFS  TR("Páky do subtrimu", "Kopie pák do subtrimu")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR("Cpy min/max to all",  "Copy min/max/center to all outputs")
 #define TR_COPY_TRIMS_TO_OFS   TR("Trimy do subtrimu", "Kopíe trimů do subtrimu")
 #define TR_INCDEC              "Zvěšit/Zmenšit"
 #define TR_GLOBALVAR           "Glob. proměnná"

--- a/radio/src/translations/de.h.txt
+++ b/radio/src/translations/de.h.txt
@@ -1022,6 +1022,7 @@
 #define TR_PTS                 "Pts"
 #define TR_SMOOTH              "Runden"
 #define TR_COPY_STICKS_TO_OFS  TR("Copy Stk ->Subtrim", "Kopie Stick to Servo-Mitte")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR3("Cpy min/max to all", "Kopiere min/max zu allen" , "Kopiere Limits & Mitte auf alle Kanäle")
 #define TR_COPY_TRIMS_TO_OFS   TR("Copy Trim->Subtrim", "Kopie Trimm to Servo-Mitte")  // "Trim to Subtrim"
 #define TR_INCDEC              "Inc/Decrement"
 #define TR_GLOBALVAR           "Global Var"

--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -1023,6 +1023,7 @@
 #define TR_PTS                         "pts"
 #define TR_SMOOTH                      "Smooth"
 #define TR_COPY_STICKS_TO_OFS          TR("Cpy stick->subtrim", "Copy sticks to subtrim")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR("Cpy min/max to all",  "Copy min/max/center to all outputs")
 #define TR_COPY_TRIMS_TO_OFS           TR("Cpy trim->subtrim", "Copy trims to subtrim")
 #define TR_INCDEC                      "Inc/Decrement"
 #define TR_GLOBALVAR                   "Global var"

--- a/radio/src/translations/es.h.txt
+++ b/radio/src/translations/es.h.txt
@@ -1027,6 +1027,7 @@
 #define TR_PTS                 "pts"
 #define TR_SMOOTH              "Smooth"
 #define TR_COPY_STICKS_TO_OFS  TR("Cpy stick->subtrim", "Copy Sticks To Offset")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR("Cpy min/max to all",  "Copy min/max/center to all outputs")
 #define TR_COPY_TRIMS_TO_OFS   TR("Cpy trim->subtrim", "Copy trims to subtrim")
 #define TR_INCDEC              "Inc/Decrement"
 #define TR_GLOBALVAR           "Global Var"

--- a/radio/src/translations/fi.h.txt
+++ b/radio/src/translations/fi.h.txt
@@ -1012,6 +1012,7 @@
 #define TR_PTS                 "pts"
 #define TR_SMOOTH              "Smooth"
 #define TR_COPY_STICKS_TO_OFS  TR("Cpy stick->subtrim", "Copy Sticks To Offset")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR("Cpy min/max to all",  "Copy min/max/center to all outputs")
 #define TR_COPY_TRIMS_TO_OFS   TR("Cpy trim->subtrim", "Copy trims to subtrim")
 #define TR_INCDEC              "Inc/Decrement"
 #define TR_GLOBALVAR           "Global Var"

--- a/radio/src/translations/fr.h.txt
+++ b/radio/src/translations/fr.h.txt
@@ -1025,6 +1025,7 @@
 #define TR_PTS                         "pts"
 #define TR_SMOOTH                      "Lissage"
 #define TR_COPY_STICKS_TO_OFS          TR("Cpy stick->subtrim", "Manche vers subtrim")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR("Cpy min/max to all",  "Copy min/max/center to all outputs")
 #define TR_COPY_TRIMS_TO_OFS           TR("Cpy trim->subtrim", "Trim vers subtrim")
 #define TR_INCDEC                      "Inc/décrementer"
 #define TR_GLOBALVAR                   "Var. globale"

--- a/radio/src/translations/it.h.txt
+++ b/radio/src/translations/it.h.txt
@@ -1019,6 +1019,7 @@
 #define TR_PTS                 "pti"
 #define TR_SMOOTH              "Smussa"
 #define TR_COPY_STICKS_TO_OFS  TR("Cpy stick->subtrim", "Copia Stick su Offset")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR("Cpy min/max to all",  "Copy min/max/center to all outputs")
 #define TR_COPY_TRIMS_TO_OFS   TR("Cpy trim->subtrim", "Copia Trim in Subtrim")
 #define TR_INCDEC              "Inc/Decrementa"
 #define TR_GLOBALVAR           "Var Globale"

--- a/radio/src/translations/nl.h.txt
+++ b/radio/src/translations/nl.h.txt
@@ -1013,6 +1013,7 @@
 #define TR_PTS                 "Ptn"
 #define TR_SMOOTH              "Zacht"
 #define TR_COPY_STICKS_TO_OFS  TR("Cpy stick->subtrim", "Kopieer Sticks naar Subtrim")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR("Cpy min/max to all",  "Copy min/max/center to all outputs")
 #define TR_COPY_TRIMS_TO_OFS   TR("Cpy trim->subtrim", "Kopieer Trim naar Subtrim")
 #define TR_INCDEC              "Inc/Decrement"
 #define TR_GLOBALVAR           "Globale Var"

--- a/radio/src/translations/pl.h.txt
+++ b/radio/src/translations/pl.h.txt
@@ -1022,6 +1022,7 @@
 #define TR_PTS                 "pkty"
 #define TR_SMOOTH              "Gładka"
 #define TR_COPY_STICKS_TO_OFS  TR("Cpy stick->subtrim", "Skopiuj Drążki Do Offsetu")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR("Cpy min/max to all",  "Copy min/max/center to all outputs")
 #define TR_COPY_TRIMS_TO_OFS   TR("Cpy trim->subtrim", "Skopiuj Trymery Do subtrymerów")
 #define TR_INCDEC              "Zwiększ/Zmnie"
 #define TR_GLOBALVAR           "Zm.Global."

--- a/radio/src/translations/pt.h.txt
+++ b/radio/src/translations/pt.h.txt
@@ -1023,6 +1023,7 @@
 #define TR_PTS                 "pts"
 #define TR_SMOOTH              "Smooth"
 #define TR_COPY_STICKS_TO_OFS  TR("Cpy stick->subtrim", "Copy Sticks To Offset")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR("Cpy min/max to all",  "Copy min/max/center to all outputs")
 #define TR_COPY_TRIMS_TO_OFS   TR("Cpy trim->subtrim", "Copy trims to subtrim")
 #define TR_INCDEC              "Inc/Decrement"
 #define TR_GLOBALVAR           "Global Var"

--- a/radio/src/translations/se.h.txt
+++ b/radio/src/translations/se.h.txt
@@ -1028,6 +1028,7 @@
 #define TR_PTS                 "pkt"
 #define TR_SMOOTH              "Mjuk"
 #define TR_COPY_STICKS_TO_OFS  TR("Cpy stick->subtrim", "Spara spakar som subtrim")
+#define TR_COPY_MIN_MAX_TO_OUTPUTS     TR("Cpy min/max to all",  "Copy min/max/center to all outputs")
 #define TR_COPY_TRIMS_TO_OFS   TR("Cpy trim->subtrim", "Spara trimmar som subtrim")
 #define TR_INCDEC              "Inkr/Dekrement"
 #define TR_GLOBALVAR           "Globala Var"


### PR DESCRIPTION
This pull request adds a new menu entry "Cpy min/max to all" under MODEL/OUTPUT.

The new entry allows users to quickly copy minimum and maximum values to all relevant outputs, improving usability and reducing repetitive manual input. Code from opentx 2.3 branch has been used to implement this functionality. 

Any feedback is welcomed.