### PR TITLE
Startup switch warning sound fix

### DIFF
--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -609,16 +609,15 @@ void checkSwitches()
 
     LED_ERROR_BEGIN();
     resetBacklightTimeout();
-
     // first - display warning
 #if defined(PCBTARANIS) || defined(PCBHORUS)|| defined(PCBI6X)
-    if ((last_bad_switches != switches_states) /*|| (last_bad_pots != bad_pots)*/) {
+#if defined(DFPLAYER)
+      dfplayerWakeup(); // allow to play the switch warning on startup
+#endif
+      if ((last_bad_switches != switches_states) /*|| (last_bad_pots != bad_pots)*/) {
       drawAlertBox(STR_SWITCHWARN, NULL, STR_PRESSANYKEYTOSKIP);
       if (last_bad_switches == 0xff /*|| last_bad_pots == 0xff*/) {
         AUDIO_ERROR_MESSAGE(AU_SWITCH_ALERT);
-        #if defined(DFPLAYER)
-            dfplayerWakeup(); // allow to play the throttle warning on startup
-        #endif
       }
       int x = SWITCH_WARNING_LIST_X, y = SWITCH_WARNING_LIST_Y;
       int numWarnings = 0;


### PR DESCRIPTION
Fix DFPlayer startup sound not playing on switch warning screen.

When no throttle warning is present but a switch warning is active,
the DFPlayer module was not awake when AUDIO_ERROR_MESSAGE(AU_SWITCH_ALERT)
was called, so no sound was produced before any key press.

Fix mirrors the approach from PR #504

Ref: OpenI6X/opentx#504