### PR TITLE
Move  menu handlers to cpp to remove duplication.

### DIFF
--- a/radio/src/gui/128x64/menu_model.cpp
+++ b/radio/src/gui/128x64/menu_model.cpp
@@ -20,6 +20,23 @@
 
 #include "opentx.h"
 
+const MenuHandlerFunc menuTabModel[]  = {
+  menuModelSelect,
+  menuModelSetup,
+  CASE_HELI(menuModelHeli)
+  CASE_FLIGHT_MODES(menuModelFlightModesAll)
+  menuModelExposAll,
+  menuModelMixAll,
+  menuModelLimits,
+  menuModelCurvesAll,
+  menuModelLogicalSwitches,
+  menuModelSpecialFunctions,
+#if defined(LUA_MODEL_SCRIPTS)
+  menuModelCustomScripts,
+#endif
+  menuModelTelemetry,
+  menuModelDisplay,
+};
 
 uint8_t editDelay(coord_t y, event_t event, uint8_t attr, const char * str, uint8_t delay)
 {

--- a/radio/src/gui/128x64/menu_radio.cpp
+++ b/radio/src/gui/128x64/menu_radio.cpp
@@ -37,3 +37,15 @@ void menuRadioSpecialFunctions(event_t event)
   }
 #endif
 }
+
+const MenuHandlerFunc menuTabGeneral[]  = {
+#if defined(RADIO_TOOLS)
+  menuRadioTools,
+#endif
+  menuRadioSetup,
+  CASE_SDCARD(menuRadioSdManager)
+  menuRadioSpecialFunctions,
+  menuRadioTrainer,
+  menuRadioHardware,
+  menuRadioVersion
+};

--- a/radio/src/gui/128x64/menus.h
+++ b/radio/src/gui/128x64/menus.h
@@ -92,18 +92,6 @@ void menuRadioHardware(event_t event);
 void menuRadioTools(event_t event);
 void menuRadioCalibration(event_t event);
 
-static const MenuHandlerFunc menuTabGeneral[]  = {
-#if defined(RADIO_TOOLS)
-  menuRadioTools,
-#endif
-  menuRadioSetup,
-  CASE_SDCARD(menuRadioSdManager)
-  menuRadioSpecialFunctions,
-  menuRadioTrainer,
-  menuRadioHardware,
-  menuRadioVersion
-};
-
 enum MenuModelIndexes {
   MENU_MODEL_SELECT,
   MENU_MODEL_SETUP,
@@ -142,28 +130,13 @@ void menuModelTelemetry(event_t event);
 void menuModelDisplay(event_t event);
 void menuModelTemplates(event_t event);
 void menuModelGVarOne(event_t event);
-
-static const MenuHandlerFunc menuTabModel[]  = {
-  menuModelSelect,
-  menuModelSetup,
-  CASE_HELI(menuModelHeli)
-  CASE_FLIGHT_MODES(menuModelFlightModesAll)
-  menuModelExposAll,
-  menuModelMixAll,
-  menuModelLimits,
-  menuModelCurvesAll,
-  menuModelLogicalSwitches,
-  menuModelSpecialFunctions,
-#if defined(LUA_MODEL_SCRIPTS)
-  menuModelCustomScripts,
-#endif
-  menuModelTelemetry,
-  menuModelDisplay,
-};
-
 void menuStatisticsView(event_t event);
 void menuStatisticsDebug(event_t event);
 void menuStatisticsDebug2(event_t event);
 #if !defined(PCBI6X)
 void menuAboutView(event_t event);
 #endif
+
+
+extern const MenuHandlerFunc menuTabModel[MENU_MODEL_PAGES_COUNT];
+extern const MenuHandlerFunc menuTabGeneral[MENU_RADIO_PAGES_COUNT];


### PR DESCRIPTION
Move  menu handlers from header to cpp file to remove duplication. This reduces flash used by about 500 bytes.